### PR TITLE
fix reading and saving settings due to missing entry

### DIFF
--- a/src/lib/utils/settings.ts
+++ b/src/lib/utils/settings.ts
@@ -9,6 +9,7 @@ export const defaultSettings = {
         showNames: true,
         showGearScore: false,
         showEsther: true,
+        positionalDmgPercent: false,
         hideLogo: false,
         accentColor: "theme-pink",
         rawSocket: false,


### PR DESCRIPTION
fixes 2 silent problems, after adding some panics/console writes they became visible:
1. while reading
"thread 'main' panicked at 'Problem parsing json from file contents: Error("missing field `positionalDmgPercent`", line: 15, column: 3)', src\main.rs:745:19"
2. while writing
"invalid args `settings` for command `save_settings`: missing field `positionalDmgPercent`"