### PR TITLE
:bug: fix: raid gate reactivity, favorite reactivity and tiny refactor

### DIFF
--- a/src/routes/logs/encounter/+page.svelte
+++ b/src/routes/logs/encounter/+page.svelte
@@ -13,28 +13,28 @@
     import DifficultyLabel from "$lib/components/shared/DifficultyLabel.svelte";
     import BossOnlyDamage from "$lib/components/shared/BossOnlyDamage.svelte";
 
-    let id = $page.url.searchParams.get("id") ?? "0";
+    let id: string;
     let encounter: Encounter;
     let fav = writable(false);
     let raidGate = writable<string | undefined>(undefined);
+
+    const loadEncounter = async () => {
+        encounter = await invoke("load_encounter", { id });
+        $fav = encounter.favorite;
+        $raidGate = $raidGates.get(encounter.currentBossName);
+    };
 
     onMount(() => {
         if ($searchStore.length > 0) {
             $backNavStore = true;
         }
 
-        (async () => {
-            encounter = await invoke("load_encounter", { id: id });
-            $fav = encounter.favorite;
-            $raidGate = $raidGates.get(encounter.currentBossName);
-        })();
+        (async () => await loadEncounter())();
     });
 
     $: {
         id = $page.url.searchParams.get("id") ?? "0";
-        (async () => {
-            encounter = await invoke("load_encounter", { id: id });
-        })();
+        (async () => await loadEncounter())();
     }
 
     async function toggle_favorite() {


### PR DESCRIPTION
When checking an encounter and using the keyboard shortcut or the button to open a recent log, it would cause the encounter to keep the old state for the raid gate and the favorite. The same thing happens if you close the log window and use the keyboard shortcut or the button to open recent log

_Before_
![LOA_Logs_OzmswW7sEu](https://github.com/snoww/loa-logs/assets/140087481/be49811d-dd37-49b6-bc3f-60792a6b26af)

_After using keyboard shortcut or the button to open recent log_
![LOA_Logs_5xazryTn3S](https://github.com/snoww/loa-logs/assets/140087481/d8afdfde-efe4-4bad-9eae-31d1ded5a701)

_Fixed_
![LOA_Logs_uxsQCgAfAp](https://github.com/snoww/loa-logs/assets/140087481/6fa4f2cf-1ad8-4703-807d-895010f5dc0f)

GIF [Before Fix](https://i.imgur.com/q2NbRtK.gif) | [After Fix](https://i.imgur.com/JMcZ7yt.gif)
