### PR TITLE
moved hiding of logs window to build time, to prevent atifacts

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -156,20 +156,23 @@ async fn main() -> Result<()> {
                 }
             }
 
+            let mut logs_visible = true;
+            if let Some(settings) = settings.clone() {
+                if settings.general.hide_logs_on_start {
+                    logs_visible = false;
+                }
+            }
+
             let logs_window =
                 WindowBuilder::new(app, "logs", tauri::WindowUrl::App("/logs".into()))
                     .title("LOA Logs")
                     .min_inner_size(650.0, 300.0)
                     .inner_size(800.0, 500.0)
+                    .visible(logs_visible)
                     .build()
                     .expect("failed to create log window");
             logs_window.restore_state(StateFlags::all()).unwrap();
             logs_window.set_decorations(true).unwrap();
-            if let Some(settings) = settings.clone() {
-                if settings.general.hide_logs_on_start {
-                    logs_window.hide().unwrap();
-                }
-            }
 
             tokio::task::spawn_blocking(move || {
                 parser::start(meter_window, ip, port, raw_socket, settings).map_err(|e| {


### PR DESCRIPTION
Set visibility of the logs window while it is being built. This prevents the window from appearing and then disappearing a split second later. Instead, it now doesn't appear at all if the setting is toggled on.