### PR TITLE
[Fix] Log panic errors to file before application termination

### DIFF
--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -83,5 +83,5 @@ pub fn get_logger() -> Result<LoggerHandle, String> {
     if let Some(logger_handle) = get_app_state().lock().unwrap().get_logger() {
         return Ok(logger_handle);
     }
-    return Err("xd".to_string());
+    return Err("AppState logger not present".to_string());
 }

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,0 +1,87 @@
+
+
+use flexi_logger::{
+    Cleanup, Criterion, DeferredNow, Duplicate, FileSpec, Logger, LoggerHandle, Naming, WriteMode
+};
+
+use log::{error, info, warn, Record};
+
+use std::sync::{Mutex, OnceLock};
+
+fn get_app_state() -> &'static Mutex<AppState> {
+    static APP_STATE: OnceLock<Mutex<AppState>> = OnceLock::new();
+    APP_STATE.get_or_init(|| Mutex::new(AppState::new()))
+}
+
+struct AppState {
+    pub logger_handle: Option<LoggerHandle>,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self {
+            logger_handle: None,
+        }
+    }
+
+    pub fn init_logger(&mut self) {
+        if let Some(_) = self.logger_handle.clone() {
+            error!("AppState logger already inited");
+            return;
+        }
+
+        let mut logger = Logger::try_with_str("info, tao=off").unwrap()
+        .log_to_file(
+            FileSpec::default()
+                .suppress_timestamp()
+                .basename("loa_logs"),
+        )
+        .use_utc()
+        .write_mode(WriteMode::BufferAndFlush)
+        .append()
+        .format(AppState::default_format_with_time)
+        .rotate(
+            Criterion::Size(5_000_000),
+            Naming::Timestamps,
+            Cleanup::KeepLogFiles(2),
+        );
+        
+        #[cfg(debug_assertions)]
+        {
+            logger = logger.duplicate_to_stdout(Duplicate::All);
+        }
+
+        self.logger_handle = Some(logger.start().unwrap());
+    }
+
+    pub fn get_logger(&self) -> Option<LoggerHandle> {
+        return self.logger_handle.clone();
+    }
+
+    fn default_format_with_time(
+        w: &mut dyn std::io::Write,
+        now: &mut DeferredNow,
+        record: &Record,
+    ) -> Result<(), std::io::Error> {
+        write!(
+            w,
+            "[{}] {} [{}] {}",
+            now.format("%Y-%m-%dT%H:%M:%S%.6fZ"),
+            record.level(),
+            record.module_path().unwrap_or("<unnamed>"),
+            record.args()
+        )
+    }
+
+}
+
+pub fn init() {
+    get_app_state().lock().unwrap().init_logger();
+}
+
+pub fn get_logger() -> Result<LoggerHandle, String> {
+    if let Some(logger_handle) = get_app_state().lock().unwrap().get_logger() {
+        return Ok(logger_handle);
+    }
+    return Err("xd".to_string());
+}

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,7 +1,5 @@
-
-
 use flexi_logger::{
-    Cleanup, Criterion, DeferredNow, Duplicate, FileSpec, Logger, LoggerHandle, Naming, WriteMode
+    Cleanup, Criterion, DeferredNow, Duplicate, FileSpec, Logger, LoggerHandle, Naming, WriteMode,
 };
 
 use log::{error, info, warn, Record};
@@ -25,27 +23,28 @@ impl AppState {
     }
 
     pub fn init_logger(&mut self) {
-        if let Some(_) = self.logger_handle.clone() {
+        if self.logger_handle.clone().is_some() {
             error!("AppState logger already inited");
             return;
         }
 
-        let mut logger = Logger::try_with_str("info, tao=off").unwrap()
-        .log_to_file(
-            FileSpec::default()
-                .suppress_timestamp()
-                .basename("loa_logs"),
-        )
-        .use_utc()
-        .write_mode(WriteMode::BufferAndFlush)
-        .append()
-        .format(AppState::default_format_with_time)
-        .rotate(
-            Criterion::Size(5_000_000),
-            Naming::Timestamps,
-            Cleanup::KeepLogFiles(2),
-        );
-        
+        let mut logger = Logger::try_with_str("info, tao=off")
+            .unwrap()
+            .log_to_file(
+                FileSpec::default()
+                    .suppress_timestamp()
+                    .basename("loa_logs"),
+            )
+            .use_utc()
+            .write_mode(WriteMode::BufferAndFlush)
+            .append()
+            .format(AppState::default_format_with_time)
+            .rotate(
+                Criterion::Size(5_000_000),
+                Naming::Timestamps,
+                Cleanup::KeepLogFiles(2),
+            );
+
         #[cfg(debug_assertions)]
         {
             logger = logger.duplicate_to_stdout(Duplicate::All);
@@ -55,7 +54,7 @@ impl AppState {
     }
 
     pub fn get_logger(&self) -> Option<LoggerHandle> {
-        return self.logger_handle.clone();
+        self.logger_handle.clone()
     }
 
     fn default_format_with_time(
@@ -72,7 +71,6 @@ impl AppState {
             record.args()
         )
     }
-
 }
 
 pub fn init() {
@@ -83,5 +81,5 @@ pub fn get_logger() -> Result<LoggerHandle, String> {
     if let Some(logger_handle) = get_app_state().lock().unwrap().get_logger() {
         return Ok(logger_handle);
     }
-    return Err("AppState logger not present".to_string());
+    Err("AppState logger not present".to_string())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -34,12 +34,7 @@ async fn main() -> Result<()> {
     std::panic::set_hook(Box::new(|info| {
         error!("Panicked: {:?}", info);
 
-        match app::get_logger() {
-            Ok(logger) => {
-                logger.flush();
-            },
-            Err(_) => {}
-        }
+        app::get_logger().unwrap().flush();
     }));
 
     let quit = CustomMenuItem::new("quit".to_string(), "Quit");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,8 @@
 )]
 
 mod parser;
+mod app;
+
 use std::{
     fs::{self, File},
     io::{Read, Write},
@@ -12,11 +14,8 @@ use std::{
 };
 
 use anyhow::Result;
-use flexi_logger::{
-    Cleanup, Criterion, DeferredNow, Duplicate, FileSpec, Logger, Naming, WriteMode,
-};
 use hashbrown::HashMap;
-use log::{error, info, warn, Record};
+use log::{error, info, warn};
 use parser::models::*;
 
 use rusqlite::{params, params_from_iter, Connection};
@@ -30,31 +29,17 @@ use window_vibrancy::{apply_blur, clear_blur};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let mut logger = Logger::try_with_str("info, tao=off")?
-        .log_to_file(
-            FileSpec::default()
-                .suppress_timestamp()
-                .basename("loa_logs"),
-        )
-        .use_utc()
-        .write_mode(WriteMode::BufferAndFlush)
-        .append()
-        .format(default_format_with_time)
-        .rotate(
-            Criterion::Size(5_000_000),
-            Naming::Timestamps,
-            Cleanup::KeepLogFiles(2),
-        );
-
-    #[cfg(debug_assertions)]
-    {
-        logger = logger.duplicate_to_stdout(Duplicate::All);
-    }
-
-    logger.start()?;
+    app::init();
 
     std::panic::set_hook(Box::new(|info| {
         error!("Panicked: {:?}", info);
+
+        match app::get_logger() {
+            Ok(logger) => {
+                logger.flush();
+            },
+            Err(_) => {}
+        }
     }));
 
     let quit = CustomMenuItem::new("quit".to_string(), "Quit");
@@ -1283,19 +1268,4 @@ fn set_clickthrough(window: tauri::Window, set: bool) {
 #[tauri::command]
 fn write_log(message: String) {
     info!("{}", message);
-}
-
-fn default_format_with_time(
-    w: &mut dyn std::io::Write,
-    now: &mut DeferredNow,
-    record: &Record,
-) -> Result<(), std::io::Error> {
-    write!(
-        w,
-        "[{}] {} [{}] {}",
-        now.format("%Y-%m-%dT%H:%M:%S%.6fZ"),
-        record.level(),
-        record.module_path().unwrap_or("<unnamed>"),
-        record.args()
-    )
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,8 +3,8 @@
     windows_subsystem = "windows"
 )]
 
-mod parser;
 mod app;
+mod parser;
 
 use std::{
     fs::{self, File},


### PR DESCRIPTION
Current code does not write panic messages to logs due to race condition which mostly/always is lost due to the nature of buffering logging before IO operation takes place thus panics end up not in file. Proposed solution should ensure that logger writes to file before application is terminated.