### PR TITLE
[Fix] Loa Logs crashes if guardian raid boss dies in 1 hit

### DIFF
--- a/src-tauri/src/parser/encounter_state.rs
+++ b/src-tauri/src/parser/encounter_state.rs
@@ -1336,7 +1336,7 @@ fn insert_data(
         .expect("failed to prepare encounter statement");
 
     encounter.duration = encounter.last_combat_packet - encounter.fight_start;
-    let duration_seconds = encounter.duration / 1000;
+    let duration_seconds = max(encounter.duration / 1000, 1);
     encounter.encounter_damage_stats.dps =
         encounter.encounter_damage_stats.total_damage_dealt / duration_seconds;
 


### PR DESCRIPTION
Simple safeguard to avoid division by zero as per panic log:
```
[2024-01-24T02:45:28.322882Z] ERROR [app] Panicked: PanicInfo { payload: Any { .. }, message: Some(attempt to divide by zero), location: Location { file: "src\\parser\\encounter_state.rs", line: 1341, col: 9 }, can_unwind: true, force_no_backtrace: false }```