### PR TITLE
[improvement] Logger directory consistency

### DIFF
--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -28,12 +28,17 @@ impl AppState {
             return;
         }
 
+        let mut resource_directory =
+            std::env::current_exe().expect("Can't find path to executable");
+        resource_directory.pop();
+
         let mut logger = Logger::try_with_str("info, tao=off")
             .unwrap()
             .log_to_file(
                 FileSpec::default()
                     .suppress_timestamp()
-                    .basename("loa_logs"),
+                    .basename("loa_logs")
+                    .directory(resource_directory),
             )
             .use_utc()
             .write_mode(WriteMode::BufferAndFlush)


### PR DESCRIPTION
This change ensures logger should always log in application directory instead of current working directory. This change also fixes issue when working in development mode that resulted in `loa_logs_rCURRENT.log` file being output to `src-tauri` directory and causing file change watcher to trigger and cause application rebuilding.