### PR TITLE
[Improvement] Window states 3

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -179,12 +179,22 @@ async fn main() -> Result<()> {
                 api.prevent_close();
 
                 if event.window().label() == METER_WINDOW_LABEL {
-                    event
-                        .window()
-                        .app_handle()
+                    let app_handle = event.window().app_handle();
+                    let meter_window = app_handle.get_window(METER_WINDOW_LABEL).unwrap();
+                    let logs_window = app_handle.get_window(LOGS_WINDOW_LABEL).unwrap();
+
+                    if logs_window.is_minimized().unwrap() {
+                        logs_window.unminimize().unwrap();
+                    }
+
+                    if meter_window.is_minimized().unwrap() {
+                        meter_window.unminimize().unwrap();
+                    }
+
+                    app_handle
                         .save_window_state(WINDOW_STATE_FLAGS)
                         .expect("failed to save window state");
-                    event.window().app_handle().exit(0);
+                    app_handle.exit(0);
                 } else if event.window().label() == LOGS_WINDOW_LABEL {
                     event.window().hide().unwrap();
                 }


### PR DESCRIPTION
Another improvement in the series for window state handling:
* Should fix meter window becoming like this
![image](https://github.com/snoww/loa-logs/assets/22958062/1c61c7a2-e982-4232-8a20-43b0160e2b61)
in case taskbar show desktop button was clicked and then loa logs was closed from task bar with right click.