### PR TITLE
[Fix] Meter window screenshot clipping

### DIFF
--- a/src/lib/components/DamageMeter.svelte
+++ b/src/lib/components/DamageMeter.svelte
@@ -307,13 +307,13 @@
         anySupportBrand = false;
     }
 
-    let targetDiv: HTMLElement;
+    let screenshotAreaDiv: HTMLElement;
 
     async function captureScreenshot() {
         takingScreenshot.set(true);
         document.body.style.pointerEvents = "none";
         setTimeout(async () => {
-            const canvas = await html2canvas(targetDiv, {
+            const canvas = await html2canvas(screenshotAreaDiv, {
                 useCORS: true,
                 backgroundColor: "#27272A"
             });
@@ -343,7 +343,7 @@
 </script>
 
 <svelte:window on:contextmenu|preventDefault />
-<div bind:this={targetDiv}>
+<div bind:this={screenshotAreaDiv} style="height: calc(100vh - 1.5rem);">
     <EncounterInfo {encounterDuration} {totalDamageDealt} {dps} {timeUntilKill} screenshotFn={captureScreenshot} />
     {#if currentBoss !== null && $settings.meter.bossHp}
         <div class="relative top-7">
@@ -393,12 +393,12 @@
                                 <th
                                     class="w-12 font-normal"
                                     use:tooltip={{ content: "% Damage buffed by Support Atk. Power buff" }}
-                                >Buff%
+                                    >Buff%
                                 </th>
                             {/if}
                             {#if anySupportBrand && $settings.meter.percentBrand}
                                 <th class="w-12 font-normal" use:tooltip={{ content: "% Damage buffed by Brand" }}
-                                >B%</th>
+                                    >B%</th>
                             {/if}
                             {#if anySupportIdentity && $settings.meter.percentIdentityBySup}
                                 <th


### PR DESCRIPTION
Following change should fix clipping of screenshot generated when clicking "Take Screenshot" button.

# Explanation
This is how window looks like:
![image](https://github.com/snoww/loa-logs/assets/22958062/01dde769-bac2-431c-9189-c55d5e6faccd)
This is how generated screenshot looks like currently:
![image](https://github.com/snoww/loa-logs/assets/22958062/8ddecce7-9a55-4770-bd8f-25e40e2a0ca4)
This is how generated screenshot looks after changes:
![image](https://github.com/snoww/loa-logs/assets/22958062/fe9e8120-ec38-4623-9ddd-39ec233e7dd9)

As can be noticed if someone likes to fit the window size with amount of ~~players~~ entities in the raid they would fall victim to clipping of bottom part of the data.