### PR TITLE
Improve Full Text Searching

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -506,12 +506,11 @@ fn setup_db(resource_path: PathBuf) -> Result<(), String> {
             PRIMARY KEY (name, encounter_id),
             FOREIGN KEY (encounter_id) REFERENCES encounter (id) ON DELETE CASCADE
         );
-        CREATE INDEX IF NOT EXISTS entity_encounter_id_index
-        ON entity (encounter_id desc);
-        CREATE INDEX IF NOT EXISTS entity_name_index
-        ON entity (name);
-        CREATE INDEX IF NOT EXISTS entity_class_index
-        ON entity (class);
+        DROP INDEX IF EXISTS entity_encounter_id_index;
+        DROP INDEX IF EXISTS entity_name_index;
+        DROP INDEX IF EXISTS entity_class_index;
+        CREATE INDEX IF NOT EXISTS entity_id_class_name_index
+        ON entity (encounter_id desc, class, name);
         ",
     ) {
         Ok(_) => (),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1265,7 +1265,13 @@ fn optimize_database(window: tauri::Window) {
         .resource_dir()
         .expect("could not get resource dir");
     let conn = get_db_connection(&path).expect("could not get db connection");
-    conn.execute("VACUUM;", params![]).unwrap();
+    conn.execute_batch(
+        "
+        INSERT INTO encounter_search(encounter_search) VALUES('optimize');
+        VACUUM;
+        ",
+    )
+    .unwrap();
     info!("optimized database");
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -567,7 +567,7 @@ fn update_db(tx: &rusqlite::Transaction) -> Result<(), rusqlite::Error> {
             INSERT INTO encounter_search(encounter_search, rowid, current_boss, players)
             VALUES('delete', old.id, old.current_boss, old.players);
         END;
-        CREATE TRIGGER encounter_preview_au AFTER UPDATE ON encounter_preview BEGIN
+        CREATE TRIGGER encounter_preview_au AFTER UPDATE OF current_boss, players ON encounter_preview BEGIN
             INSERT INTO encounter_search(encounter_search, rowid, current_boss, players)
             VALUES('delete', old.id, old.current_boss, old.players);
             INSERT INTO encounter_search(rowid, current_boss, players)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -34,7 +34,8 @@ const WINDOW_STATE_FLAGS: StateFlags = StateFlags::from_bits_truncate(
     StateFlags::FULLSCREEN.bits()
         | StateFlags::MAXIMIZED.bits()
         | StateFlags::POSITION.bits()
-        | StateFlags::SIZE.bits(),
+        | StateFlags::SIZE.bits()
+        | StateFlags::VISIBLE.bits(),
 );
 
 #[tokio::main]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -548,7 +548,6 @@ fn migration_full_text_search(tx: &Transaction) -> Result<(), rusqlite::Error> {
         ALTER TABLE encounter DROP COLUMN boss_only_damage;
 
         CREATE INDEX encounter_preview_favorite_index ON encounter_preview(favorite);
-        CREATE INDEX encounter_preview_current_boss_difficulty_index ON encounter_preview(current_boss, difficulty);
         CREATE INDEX encounter_preview_fight_start_index ON encounter_preview(fight_start);
         CREATE INDEX encounter_preview_my_dps_index ON encounter_preview(my_dps);
         CREATE INDEX encounter_preview_duration_index ON encounter_preview(duration);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
                 .path_resolver()
                 .resource_dir()
                 .expect("could not get resource dir");
-            std::thread::sleep(std::time::Duration::from_secs(20));
+
             match setup_db(&resource_path) {
                 Ok(_) => (),
                 Err(e) => {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -632,12 +632,7 @@ fn load_encounters_preview(
 
     let mut params = vec![min_duration.to_string()];
 
-    let search_words: Vec<&str> = if search.chars().any(|c| !c.is_whitespace()) {
-        search.split_whitespace().collect()
-    } else {
-        vec![""]
-    };
-
+    let search_words: Vec<&str> = search.split_whitespace().collect();
     params.extend(
         search_words
             .iter()
@@ -646,11 +641,11 @@ fn load_encounters_preview(
 
     let word_count = search_words.len();
 
-    let join_clauses = (0..word_count).fold(String::new(), |acc, i| {
+    let join_clauses = (0..search_words.len().max(1)).fold(String::new(), |acc, i| {
         acc + &format!("JOIN entity ent{} ON e.id = ent{}.encounter_id\n    ", i, i)
     });
 
-    let input_filter = (0..word_count)
+    let input_filter = (0..search_words.len())
     .fold(String::new(), |acc, i| {
         acc + &format!(
             "AND ((current_boss LIKE '%' || ? || '%') OR (ent{}.class LIKE '%' || ? || '%') OR (ent{}.name LIKE '%' || ? || '%'))\n    ",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -610,9 +610,9 @@ fn load_encounters_preview(
         let mut placeholders = "?,".repeat(filter.bosses.len());
         placeholders.pop(); // remove trailing comma
         params.extend(filter.bosses);
-        &format!("AND e.current_boss IN ({})", placeholders)
+        format!("AND e.current_boss IN ({})", placeholders)
     } else {
-        ""
+        "".to_string()
     };
 
     let raid_clear_filter = if filter.cleared {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -511,8 +511,6 @@ fn update_db(tx: &rusqlite::Transaction) -> Result<(), rusqlite::Error> {
             FOREIGN KEY (id) REFERENCES encounter(id) ON DELETE CASCADE
         );
 
-        -- migrate old data with the help of an index
-        CREATE INDEX encounter_preview_migration_index ON entity(encounter_id, class_id, name, dps) WHERE entity_type = 'PLAYER';
         INSERT INTO encounter_preview SELECT
             id, fight_start, current_boss, duration, 
             (
@@ -528,7 +526,6 @@ fn update_db(tx: &rusqlite::Transaction) -> Result<(), rusqlite::Error> {
             ) AS my_dps,
             favorite, cleared, boss_only_damage
         FROM encounter;
-        DROP INDEX encounter_preview_migration_index;
 
         DROP INDEX IF EXISTS encounter_fight_start_index;
         DROP INDEX IF EXISTS encounter_current_boss_index;

--- a/src-tauri/src/parser/models.rs
+++ b/src-tauri/src/parser/models.rs
@@ -654,7 +654,6 @@ pub struct EncountersOverview {
 #[serde(rename_all = "camelCase", default)]
 pub struct SearchFilter {
     pub bosses: Vec<String>,
-    pub classes: Vec<String>,
     pub min_duration: i32,
     pub max_duration: i32,
     pub cleared: bool,

--- a/src-tauri/src/parser/models.rs
+++ b/src-tauri/src/parser/models.rs
@@ -633,7 +633,7 @@ pub struct EncounterPreview {
     pub id: i32,
     pub fight_start: i64,
     pub boss_name: String,
-    pub duration: i32,
+    pub duration: i64,
     pub classes: Vec<i32>,
     pub names: Vec<String>,
     pub difficulty: Option<String>,

--- a/src-tauri/src/parser/utils.rs
+++ b/src-tauri/src/parser/utils.rs
@@ -7,7 +7,7 @@ use hashbrown::HashMap;
 use moka::sync::Cache;
 use rusqlite::{params, Transaction};
 use serde_json::json;
-use std::cmp::{max, Ordering};
+use std::cmp::{max, Ordering, Reverse};
 use std::collections::BTreeMap;
 
 pub fn encounter_entity_from_entity(entity: &Entity) -> EncounterEntity {
@@ -1074,7 +1074,7 @@ pub fn insert_data(
         .find(|e| e.name == encounter.local_player)
         .and_then(|e| Some(e.damage_stats.dps))
         .unwrap_or_default();
-    players.sort_unstable_by_key(|e| e.damage_stats.damage_dealt);
+    players.sort_unstable_by_key(|e| Reverse(e.damage_stats.damage_dealt));
     let preview_players = players
         .into_iter()
         .map(|e| format!("{}:{}", e.class_id, e.name))
@@ -1085,16 +1085,16 @@ pub fn insert_data(
         .prepare_cached(
             "
     INSERT INTO encounter_preview (
-        id
+        id,
         fight_start,
         current_boss,
         duration,
         payers,
         difficulty,
         local_player,
-        my_dps
+        my_dps,
         cleared,
-        boss_only_damage,
+        boss_only_damage
     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         )
         .expect("failed to prepare encounter preview statement");

--- a/src-tauri/src/parser/utils.rs
+++ b/src-tauri/src/parser/utils.rs
@@ -703,6 +703,10 @@ pub fn insert_data(
             "
     INSERT INTO encounter (
         last_combat_packet,
+        fight_start,
+        local_player,
+        current_boss,
+        duration,
         total_damage_dealt,
         top_damage_dealt,
         total_damage_taken,
@@ -714,8 +718,11 @@ pub fn insert_data(
         total_effective_shielding,
         applied_shield_buffs,
         misc,
+        difficulty,
+        cleared,
+        boss_only_damage,
         version
-    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
         )
         .expect("failed to prepare encounter statement");
 
@@ -786,6 +793,10 @@ pub fn insert_data(
     encounter_stmt
         .execute(params![
             encounter.last_combat_packet,
+            encounter.fight_start,
+            encounter.local_player,
+            encounter.current_boss_name,
+            encounter.duration,
             encounter.encounter_damage_stats.total_damage_dealt,
             encounter.encounter_damage_stats.top_damage_dealt,
             encounter.encounter_damage_stats.total_damage_taken,
@@ -797,6 +808,9 @@ pub fn insert_data(
             encounter.encounter_damage_stats.total_effective_shielding,
             json!(encounter.encounter_damage_stats.applied_shield_buffs),
             json!(misc),
+            raid_difficulty,
+            raid_clear,
+            encounter.boss_only_damage,
             DB_VERSION
         ])
         .expect("failed to insert encounter");
@@ -1059,59 +1073,6 @@ pub fn insert_data(
             ])
             .expect("failed to insert entity");
     }
-
-    let mut players = encounter
-        .entities
-        .values()
-        .filter(|e| {
-            ((e.entity_type == EntityType::PLAYER && e.class_id != 0 && e.max_hp > 0)
-                || e.name == encounter.local_player)
-                && e.damage_stats.damage_dealt > 0
-        })
-        .collect::<Vec<_>>();
-    let local_player_dps = players
-        .iter()
-        .find(|e| e.name == encounter.local_player)
-        .and_then(|e| Some(e.damage_stats.dps))
-        .unwrap_or_default();
-    players.sort_unstable_by_key(|e| e.damage_stats.damage_dealt);
-    let preview_players = players
-        .into_iter()
-        .map(|e| format!("{}:{}", e.class_id, e.name))
-        .collect::<Vec<_>>()
-        .join(",");
-
-    let mut encounter_preview_stmt = tx
-        .prepare_cached(
-            "
-    INSERT INTO encounter_preview (
-        id
-        fight_start,
-        current_boss,
-        duration,
-        payers,
-        difficulty,
-        local_player,
-        my_dps
-        cleared,
-        boss_only_damage,
-    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-        )
-        .expect("failed to prepare encounter preview statement");
-    encounter_preview_stmt
-        .execute(params![
-            last_insert_id,
-            encounter.fight_start,
-            encounter.current_boss_name,
-            encounter.duration,
-            preview_players,
-            raid_difficulty,
-            encounter.local_player,
-            local_player_dps,
-            raid_clear,
-            encounter.boss_only_damage
-        ])
-        .expect("failed to insert encounter preview");
 }
 
 pub fn map_status_effect(se: &StatusEffectDetails, custom_id_map: &mut HashMap<u32, u32>) -> u32 {

--- a/src/lib/components/settings/ColorSettings.svelte
+++ b/src/lib/components/settings/ColorSettings.svelte
@@ -40,7 +40,7 @@
                     <div class="flex items-center space-x-1">
                         <img
                             class="size-8"
-                            src={$classIconCache[classNameToClassId[classColor[0]]]}
+                            src={$classIconCache[classNameToClassId[classColor[0]] || 0]}
                             alt={classColor[0]} />
                         <div class="text-gray-100">{classColor[0]}</div>
                     </div>

--- a/src/lib/components/table/TableFilter.svelte
+++ b/src/lib/components/table/TableFilter.svelte
@@ -44,14 +44,14 @@
 
         return (evt: Event & { currentTarget: EventTarget & HTMLInputElement }) => {
             clearTimeout(timer);
-            const timeout = search.length ? milliseconds : 0;
+            const timeout = search.length >= 3 ? milliseconds : 0;
             timer = setTimeout(() => fn(evt), timeout);
             // currentTarget is null because the event expires
         };
     }
 
     const handleSearchInput = debounce(() => {
-        $searchStore = search;
+        $searchStore = search.length >= 3 ? search : "";
     }, 300);
 
     const isFilterButton = (element: HTMLElement) => {

--- a/src/lib/components/table/TableFilter.svelte
+++ b/src/lib/components/table/TableFilter.svelte
@@ -46,21 +46,16 @@
     function debounce(fn: FormEventHandler<HTMLInputElement>, milliseconds: number) {
         let timer: number | undefined;
 
-        if ($searchStore.length === 0) {
-            return fn;
-        }
-
         return (evt: Event & { currentTarget: EventTarget & HTMLInputElement }) => {
             clearTimeout(timer);
-            timer = setTimeout(() => {
-                fn(evt);
-            }, milliseconds);
+            const timeout = $searchStore.length ? milliseconds : 0;
+            timer = setTimeout(() => fn(evt), timeout);
         };
     }
 
     const handleSearchInput = debounce((e) => {
         loadEncountersFn();
-    }, 500);
+    }, 300);
 
     const isFilterButton = (element: HTMLElement) => {
         return element.classList.contains("filter-button");

--- a/src/lib/components/table/TableFilter.svelte
+++ b/src/lib/components/table/TableFilter.svelte
@@ -23,10 +23,6 @@
     let deleteConfirm = false;
 
     onMount(() => {
-        if ($searchFilter.minDuration === -1) {
-            $searchFilter.minDuration = $settings.logs.minEncounterDuration;
-        }
-
         const clickOutside = (event: MouseEvent) => {
             if (filterDiv && filterDiv.contains(event.target as Node)) {
                 return;

--- a/src/lib/constants/classes.ts
+++ b/src/lib/constants/classes.ts
@@ -40,7 +40,7 @@ export const classesMap: ClassMap = {
     604: "Alchemist"
 };
 
-export const classNameToClassId: { [key: string]: number } = {
+export const classNameToClassId: { [key: string]: number | undefined } = {
     "Unknown": 0,
     "Warrior (Male)": 101,
     "Berserker": 102,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -441,7 +441,6 @@ export interface EncounterDbInfo {
 export class SearchFilter {
     bosses: Set<string>;
     encounters: Set<string>;
-    classes: Set<string>;
     minDuration: number;
     favorite: boolean;
     cleared: boolean;
@@ -453,7 +452,6 @@ export class SearchFilter {
     constructor(minDuration = -1) {
         this.bosses = new Set();
         this.encounters = new Set();
-        this.classes = new Set();
         this.minDuration = minDuration;
         this.favorite = false;
         this.cleared = false;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -459,7 +459,7 @@ export class SearchFilter {
         this.cleared = false;
         this.difficulty = "";
         this.bossOnlyDamage = false;
-        this.sort = "fight_start";
+        this.sort = "id";
         this.order = 2;
     }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -443,7 +443,6 @@ export class SearchFilter {
     encounters: Set<string>;
     classes: Set<string>;
     minDuration: number;
-    maxDuration: number;
     favorite: boolean;
     cleared: boolean;
     difficulty: string;
@@ -456,7 +455,6 @@ export class SearchFilter {
         this.encounters = new Set();
         this.classes = new Set();
         this.minDuration = minDuration;
-        this.maxDuration = -1;
         this.favorite = false;
         this.cleared = false;
         this.difficulty = "";

--- a/src/routes/logs/+page.svelte
+++ b/src/routes/logs/+page.svelte
@@ -87,10 +87,11 @@
                 bosses.push(...encounterMap[raid][encounter]);
             }
         }
-        // word boundary (\b) + word (\S+) + colon (:)
+        // start or space (^|\s) + word (\w+) + colon or space or end (:|\s|$)
+        // using match (?:) and lookahead (?=) https://regex101.com/r/1cMFH8/1
         // if word is a valid className, replace it with the classId
-        // example: "bard:Anyduck artillerist:" -> "204:Anyduck 504:"
-        let searchQuery = search.replace(/\b(\S+):/g, (_, word: string) => {
+        // example: "bard:Anyduck shadowhunter" -> "204:Anyduck 403"
+        let searchQuery = search.replace(/(?:^|\s)\w+(?=:|\s|$)/g, (word: string) => {
             const className = word[0].toUpperCase() + word.substring(1).toLowerCase();
             return String(classNameToClassId[className] || word);
         });

--- a/src/routes/logs/+page.svelte
+++ b/src/routes/logs/+page.svelte
@@ -152,8 +152,8 @@
         let order = $searchFilter.sort === sort ? ($searchFilter.order + 1) % 3 : 1;
 
         if (order === 0) {
-            $searchFilter.sort = "fight_start";
-            $searchFilter.order = sort === "fight_start" ? 1 : 2;
+            $searchFilter.sort = "id";
+            $searchFilter.order = sort === "id" ? 1 : 2;
         } else {
             $searchFilter.sort = sort;
             $searchFilter.order = order;

--- a/src/routes/logs/+page.svelte
+++ b/src/routes/logs/+page.svelte
@@ -281,7 +281,7 @@
                     </tr>
                 </thead>
                 <tbody class="bg-neutral-800 tracking-tight">
-                    {#each encounters as encounter (encounter.fightStart)}
+                    {#each encounters as encounter (encounter.id)}
                         <tr class="border-b border-gray-700 hover:bg-zinc-700" id="encounter-{encounter.id}">
                             <td class="px-2 py-3">
                                 {#if selectMode}

--- a/src/routes/logs/+page.svelte
+++ b/src/routes/logs/+page.svelte
@@ -51,13 +51,15 @@
         }
     }
 
-    $: {
-        $searchFilter = $searchFilter;
-        loadEncounters();
+    // Initialize `minDuration` here to not trigger a reload of encounters
+    // TODO: move this into `SearchFilter` constructor?
+    if ($searchFilter.minDuration === -1) {
+        $searchFilter.minDuration = $settings.logs.minEncounterDuration;
     }
+    // TODO: make `loadEncounters()` take `searchFilter` and `pageStore` as arguments
+    $: $searchFilter && loadEncounters();
 
     onMount(async () => {
-        await loadEncounters();
         if ($miscSettings) {
             const version = await getVersion();
             if (!$miscSettings.viewedChangelog || $miscSettings.version !== version) {


### PR DESCRIPTION
## Features
- Strips diacritics, making it easy to search for European usernames like "Rosé"
- Allow searching for class and username pairs like "shadowhunter:Gaël"
- Improves encounter preview searching performance by up to 300x times
- Run database migrations inside a transaction to avoid borking the file

## Benchmark
<details>
  <summary>Benchmarking Environment</summary>
  Using 800MiB encounters.db file, thanks to <a href="http://discordapp.com/users/302093978613055499">b14ckout</a> for providing it<br>
  The executable is compiled in release mode, with each query run only once 😐<br>
  It was executed on a laptop with an external SSD connected via USB3 and an NVMe SSD<br>
  <img src="https://github.com/user-attachments/assets/653743cd-dbe3-4d32-bd91-7d355e4a8866">
  <img src="https://github.com/user-attachments/assets/ea749c12-6c32-4d9c-864a-8e24ab3b2bf6">
</details>

| Method    | Refresh | Search "cyn" | Search "red" | Class "Bard" | Migration |
|-----------|--------:|-------------:|-------------:|-------------:|----------:|
| FTS5 USB3 |     2ms |          8ms |          3ms |          7ms |     20.7s |
| FTS5 NVMe |     1ms |         12ms |          1ms |         13ms |     14.0s |
| LIKE USB3 |   312ms |        381ms |        348ms |        455ms |      0.2s |
| LIKE NVMe |   244ms |        308ms |        289ms |        244ms | [2.3s][f] |

[f]: ## "flaky run? should be around 0s"

## Problems
- Need to change encounter inserting code (I can't find it, is it in meter-core?)
- Running the new migration blocks the main thread for a noticeable amount of time. Can we run it on another thread?
- Old `update_db` function was run on every launch. Is it okay to run it only once and alter those columns to `NOT NULL`?

## Notes
- Preview information was split into a separate table `encounter_preview`, because the `difficulty TEXT` column was stored in the same overflow pages with big JSON blobs, making it costly to retrieve. And I couldn't force the query planner to use a covering index
- Now there is no need to query `encounter` and `entity` tables. So you can go full NoSQL mode and store encounter info with entities as one big JSON blob, making it easier to retrieve, store, and **compress** this data
- I tried to compress `encounters.db` using the SQLite ZSTD VFS extension, but ran into big performance issues. After this is merged, it would be easy to add compression support