### PR TITLE
Makes `cargo tauri build` work again

### DIFF
--- a/src/routes/logs/encounter/[id]/+page.ts
+++ b/src/routes/logs/encounter/[id]/+page.ts
@@ -2,6 +2,8 @@ import { invoke } from "@tauri-apps/api/tauri";
 import type { Encounter } from '$lib/types';
 import type { PageLoad } from './$types';
 
+export const prerender: boolean = false;
+
 export const load: PageLoad = async ({ params }) => {
     // If there's no such id this return `Encounter` with all fields zeroed
     const encounter = await invoke("load_encounter", { id: params.id }) as Encounter;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -11,7 +11,9 @@ const config = {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter({
+			fallback: "index.html"
+		})
 	}
 };
 


### PR DESCRIPTION
Fixes #109
- Doesn't tries to prerender `/logs/encounter/[id]` route

Whoops, I didn't notice that this was built with `prerender = true`. Now it makes sense that routes with parameters weren't used

But there should be no disadvantage to turning it into an SPA. [Here](https://github.com/tauri-apps/tauri/discussions/6423#discussioncomment-5352675) are some notes on that

I tested this in the release mode with an installer, and it works now


