### PR TITLE
Hotfix sql typo in `delete_all_uncleared_encounters`

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1289,7 +1289,7 @@ fn delete_all_uncleared_encounters(window: tauri::Window, keep_favorites: bool) 
     } else {
         conn.execute(
             "DELETE FROM encounter
-            WHERE (
+            WHERE id IN (
                 SELECT id
                 FROM encounter_preview
                 WHERE cleared = 0


### PR DESCRIPTION
Respect `cleared` flag when deleting uncleared encounters