### PR TITLE
Add Total DPS to average and 10s dps chart tooltips

### DIFF
--- a/src/lib/utils/dpsCharts.ts
+++ b/src/lib/utils/dpsCharts.ts
@@ -207,8 +207,10 @@ export function getAverageDpsChart(
                 const bossTooltips: string[] = [];
                 const tree = new BTree(undefined, (a, b) => b - a);
                 const length = Object.keys(chartablePlayers).length;
-                params.forEach((param) => generateTooltip(param, bossTooltips, tree, deathTimes, time, length));
-                tooltipStr += bossTooltips.join("") + tree.valuesArray().join("") + "</div>";
+                const totalDps = { value: 0 }
+                params.forEach((param) => generateTooltip(param, bossTooltips, totalDps, tree, deathTimes, time, length));
+                const totalDpsString = `<div style="display:flex; justify-content: space-between;"><div style="padding-right: 1rem">Total DPS</div><div style="">${totalDps.value}</div></div>`
+                tooltipStr += bossTooltips.join("") + totalDpsString + tree.valuesArray().join("") + "</div>";
                 return tooltipStr;
             }
         },
@@ -287,8 +289,9 @@ export function getRollingDpsChart(
                 const bossTooltips: string[] = [];
                 const length = Object.keys(chartablePlayers).length;
                 const tree = new BTree(undefined, (a, b) => b - a);
-                params.forEach((param) => generateTooltip(param, bossTooltips, tree, deathTimes, time, length));
-                tooltipStr += bossTooltips.join("") + tree.valuesArray().join("") + "</div>";
+                const totalDps = { value: 0 }
+                const totalDpsString = `<div style="display:flex; justify-content: space-between;"><div style="padding-right: 1rem">Total DPS</div><div style="">${totalDps.value}</div></div>`
+                tooltipStr += bossTooltips.join("") + totalDpsString + tree.valuesArray().join("") + "</div>";
                 return tooltipStr;
             }
         },
@@ -633,6 +636,7 @@ export function getOpenerSkills(skills: MiniSkill[], x: number): OpenerSkill[] {
 function generateTooltip(
     param: any,
     bossTooltips: string[],
+    totalDps: { value: number; },
     tree: BTree,
     deathTimes: { [key: string]: number },
     time: string,
@@ -655,6 +659,7 @@ function generateTooltip(
             label = "💀 " + label;
         }
         const dps = Number(value);
+        totalDps.value += dps
         value = abbreviateNumber(value);
         label =
             `<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;background-color:${param.color}"></span>` +


### PR DESCRIPTION
Adding Total DPS to the average and 10s dps chart tooltips. This code is untested. (did not try building the project)