### PR TITLE
Feature: Add Support Buffs Overtime

### DIFF
--- a/src/lib/components/logs/LogDamageMeter.svelte
+++ b/src/lib/components/logs/LogDamageMeter.svelte
@@ -119,7 +119,7 @@
                 let buffsSeries = getSupportSynergiesOverTime(
                     encounter,
                     chartablePlayers,
-                    encounter.encounterDamageStats.misc?.partyInfo! || {},
+                    enc.partyInfo!,
                     encounter.fightStart,
                     encounter.lastCombatPacket,
                     intervalMs,
@@ -139,7 +139,7 @@
                 let buffsSeries = getSupportSynergiesOverTime(
                     encounter,
                     chartablePlayers,
-                    encounter.encounterDamageStats.misc?.partyInfo! || {},
+                    enc.partyInfo!,
                     encounter.fightStart,
                     encounter.lastCombatPacket,
                     intervalMs,
@@ -159,7 +159,7 @@
                 let buffsSeries = getSupportSynergiesOverTime(
                     encounter,
                     chartablePlayers,
-                    encounter.encounterDamageStats.misc?.partyInfo! || {},
+                    enc.partyInfo!,
                     encounter.fightStart,
                     encounter.lastCombatPacket,
                     intervalMs,
@@ -179,7 +179,7 @@
                 let buffsSeries = getSupportSynergiesOverTime(
                     encounter,
                     chartablePlayers,
-                    encounter.encounterDamageStats.misc?.partyInfo! || {},
+                    enc.partyInfo!,
                     encounter.fightStart,
                     encounter.lastCombatPacket,
                     intervalMs,
@@ -797,16 +797,7 @@
                         onclick={() => (chartType = ChartType.ROLLING_DPS)}>
                         10s DPS Window
                     </button>
-                    {#if enc.hasAnySkillCastLog}
-                        {#if enc.anySupportBrand}
-                            <button
-                                class="rounded-sm px-2 py-1"
-                                class:bg-accent-900={chartType === ChartType.BRAND_BUFF}
-                                class:bg-gray-700={chartType !== ChartType.BRAND_BUFF}
-                                onclick={() => (chartType = ChartType.BRAND_BUFF)}>
-                                Brand Buffs
-                            </button>
-                        {/if}
+                    {#if enc.anySkillCastLog}
                         {#if enc.anySupportBuff}
                             <button
                                 class="rounded-sm px-2 py-1"
@@ -816,13 +807,22 @@
                                 AP Buffs
                             </button>
                         {/if}
+                        {#if enc.anySupportBrand}
+                            <button
+                                class="rounded-sm px-2 py-1"
+                                class:bg-accent-900={chartType === ChartType.BRAND_BUFF}
+                                class:bg-gray-700={chartType !== ChartType.BRAND_BUFF}
+                                onclick={() => (chartType = ChartType.BRAND_BUFF)}>
+                                Brand
+                            </button>
+                        {/if}
                         {#if enc.anySupportIdentity}
                             <button
                                 class="rounded-sm px-2 py-1"
                                 class:bg-accent-900={chartType === ChartType.IDENTITY_BUFF}
                                 class:bg-gray-700={chartType !== ChartType.IDENTITY_BUFF}
                                 onclick={() => (chartType = ChartType.IDENTITY_BUFF)}>
-                                Identity Buffs
+                                Identity
                             </button>
                         {/if}
                         {#if enc.anySupportHat}
@@ -831,7 +831,7 @@
                                 class:bg-accent-900={chartType === ChartType.HAT_BUFF}
                                 class:bg-gray-700={chartType !== ChartType.HAT_BUFF}
                                 onclick={() => (chartType = ChartType.HAT_BUFF)}>
-                                Hyper Awakening Technique Buffs
+                                H.A Skill
                             </button>
                         {/if}
                     {/if}

--- a/src/lib/components/logs/LogDamageMeter.svelte
+++ b/src/lib/components/logs/LogDamageMeter.svelte
@@ -797,34 +797,44 @@
                         onclick={() => (chartType = ChartType.ROLLING_DPS)}>
                         10s DPS Window
                     </button>
-                    <button
-                        class="rounded-sm px-2 py-1"
-                        class:bg-accent-900={chartType === ChartType.BRAND_BUFF}
-                        class:bg-gray-700={chartType !== ChartType.BRAND_BUFF}
-                        onclick={() => (chartType = ChartType.BRAND_BUFF)}>
-                        Brand Buffs
-                    </button>
-                    <button
-                        class="rounded-sm px-2 py-1"
-                        class:bg-accent-900={chartType === ChartType.AP_BUFF}
-                        class:bg-gray-700={chartType !== ChartType.AP_BUFF}
-                        onclick={() => (chartType = ChartType.AP_BUFF)}>
-                        AP Buffs
-                    </button>
-                    <button
-                        class="rounded-sm px-2 py-1"
-                        class:bg-accent-900={chartType === ChartType.IDENTITY_BUFF}
-                        class:bg-gray-700={chartType !== ChartType.IDENTITY_BUFF}
-                        onclick={() => (chartType = ChartType.IDENTITY_BUFF)}>
-                        Identity Buffs
-                    </button>
-                    <button
-                        class="rounded-sm px-2 py-1"
-                        class:bg-accent-900={chartType === ChartType.HAT_BUFF}
-                        class:bg-gray-700={chartType !== ChartType.HAT_BUFF}
-                        onclick={() => (chartType = ChartType.HAT_BUFF)}>
-                        Hyper Awakening Technique Buffs
-                    </button>
+                    {#if enc.hasAnySkillCastLog}
+                        {#if enc.anySupportBrand}
+                            <button
+                                class="rounded-sm px-2 py-1"
+                                class:bg-accent-900={chartType === ChartType.BRAND_BUFF}
+                                class:bg-gray-700={chartType !== ChartType.BRAND_BUFF}
+                                onclick={() => (chartType = ChartType.BRAND_BUFF)}>
+                                Brand Buffs
+                            </button>
+                        {/if}
+                        {#if enc.anySupportBuff}
+                            <button
+                                class="rounded-sm px-2 py-1"
+                                class:bg-accent-900={chartType === ChartType.AP_BUFF}
+                                class:bg-gray-700={chartType !== ChartType.AP_BUFF}
+                                onclick={() => (chartType = ChartType.AP_BUFF)}>
+                                AP Buffs
+                            </button>
+                        {/if}
+                        {#if enc.anySupportIdentity}
+                            <button
+                                class="rounded-sm px-2 py-1"
+                                class:bg-accent-900={chartType === ChartType.IDENTITY_BUFF}
+                                class:bg-gray-700={chartType !== ChartType.IDENTITY_BUFF}
+                                onclick={() => (chartType = ChartType.IDENTITY_BUFF)}>
+                                Identity Buffs
+                            </button>
+                        {/if}
+                        {#if enc.anySupportHat}
+                            <button
+                                class="rounded-sm px-2 py-1"
+                                class:bg-accent-900={chartType === ChartType.HAT_BUFF}
+                                class:bg-gray-700={chartType !== ChartType.HAT_BUFF}
+                                onclick={() => (chartType = ChartType.HAT_BUFF)}>
+                                Hyper Awakening Technique Buffs
+                            </button>
+                        {/if}
+                    {/if}
                 {:else if playerName !== "" && meterState === MeterState.PLAYER}
                     <!--  -->
                 {/if}

--- a/src/lib/components/logs/LogDamageMeter.svelte
+++ b/src/lib/components/logs/LogDamageMeter.svelte
@@ -35,6 +35,7 @@
         uploadErrorMessage,
         uploadErrorStore
     } from "$lib/utils/stores";
+    import { getSupportSynergiesOverTime, getSupportSynergiesOverTimeChart } from "$lib/utils/supportBuffCharts";
     import { LOG_SITE_URL, uploadLog } from "$lib/utils/sync";
     import { tooltip } from "$lib/utils/tooltip";
     import { invoke } from "@tauri-apps/api/tauri";
@@ -112,6 +113,86 @@
                     1
                 );
                 chartOptions = getRollingDpsChart(chartablePlayers, legendNames, chartPlayers, bossChart, deathTimes);
+            } else if (chartType === ChartType.BRAND_BUFF) {
+                const legendNames = new Array<string>();
+                const intervalMs = 5000;
+                let buffsSeries = getSupportSynergiesOverTime(
+                    encounter,
+                    chartablePlayers,
+                    encounter.encounterDamageStats.misc?.partyInfo! || {},
+                    encounter.fightStart,
+                    encounter.lastCombatPacket,
+                    intervalMs,
+                    legendNames
+                );
+                let bossChart = getBossHpSeries(bossHpLogs, legendNames, buffsSeries[0].data.length, 5);
+                chartOptions = getSupportSynergiesOverTimeChart(
+                    legendNames,
+                    buffsSeries,
+                    "_1_",
+                    bossChart,
+                    $skillIcon.path
+                );
+            } else if (chartType === ChartType.AP_BUFF) {
+                const legendNames = new Array<string>();
+                const intervalMs = 5000;
+                let buffsSeries = getSupportSynergiesOverTime(
+                    encounter,
+                    chartablePlayers,
+                    encounter.encounterDamageStats.misc?.partyInfo! || {},
+                    encounter.fightStart,
+                    encounter.lastCombatPacket,
+                    intervalMs,
+                    legendNames
+                );
+                let bossChart = getBossHpSeries(bossHpLogs, legendNames, buffsSeries[0].data.length, 5);
+                chartOptions = getSupportSynergiesOverTimeChart(
+                    legendNames,
+                    buffsSeries,
+                    "_0_",
+                    bossChart,
+                    $skillIcon.path
+                );
+            } else if (chartType === ChartType.IDENTITY_BUFF) {
+                const legendNames = new Array<string>();
+                const intervalMs = 5000;
+                let buffsSeries = getSupportSynergiesOverTime(
+                    encounter,
+                    chartablePlayers,
+                    encounter.encounterDamageStats.misc?.partyInfo! || {},
+                    encounter.fightStart,
+                    encounter.lastCombatPacket,
+                    intervalMs,
+                    legendNames
+                );
+                let bossChart = getBossHpSeries(bossHpLogs, legendNames, buffsSeries[0].data.length, 5);
+                chartOptions = getSupportSynergiesOverTimeChart(
+                    legendNames,
+                    buffsSeries,
+                    "_2_",
+                    bossChart,
+                    $skillIcon.path
+                );
+            } else if (chartType === ChartType.HAT_BUFF) {
+                const legendNames = new Array<string>();
+                const intervalMs = 5000;
+                let buffsSeries = getSupportSynergiesOverTime(
+                    encounter,
+                    chartablePlayers,
+                    encounter.encounterDamageStats.misc?.partyInfo! || {},
+                    encounter.fightStart,
+                    encounter.lastCombatPacket,
+                    intervalMs,
+                    legendNames
+                );
+                let bossChart = getBossHpSeries(bossHpLogs, legendNames, buffsSeries[0].data.length, 5);
+                chartOptions = getSupportSynergiesOverTimeChart(
+                    legendNames,
+                    buffsSeries,
+                    "_3_",
+                    bossChart,
+                    $skillIcon.path
+                );
             } else if (chartType === ChartType.SKILL_LOG && player && player.entityType === EntityType.PLAYER) {
                 if (
                     Object.entries(player.skills).some(
@@ -301,10 +382,7 @@
                 return;
             }
 
-            const canvas = await html2canvas(targetDiv, {
-                useCORS: true,
-                backgroundColor: "#27272A"
-            });
+            const canvas = await html2canvas(targetDiv, { useCORS: true, backgroundColor: "#27272A" });
 
             canvas.toBlob(async (blob) => {
                 if (!blob) return;
@@ -719,6 +797,34 @@
                         onclick={() => (chartType = ChartType.ROLLING_DPS)}>
                         10s DPS Window
                     </button>
+                    <button
+                        class="rounded-sm px-2 py-1"
+                        class:bg-accent-900={chartType === ChartType.BRAND_BUFF}
+                        class:bg-gray-700={chartType !== ChartType.BRAND_BUFF}
+                        onclick={() => (chartType = ChartType.BRAND_BUFF)}>
+                        Brand Buffs
+                    </button>
+                    <button
+                        class="rounded-sm px-2 py-1"
+                        class:bg-accent-900={chartType === ChartType.AP_BUFF}
+                        class:bg-gray-700={chartType !== ChartType.AP_BUFF}
+                        onclick={() => (chartType = ChartType.AP_BUFF)}>
+                        AP Buffs
+                    </button>
+                    <button
+                        class="rounded-sm px-2 py-1"
+                        class:bg-accent-900={chartType === ChartType.IDENTITY_BUFF}
+                        class:bg-gray-700={chartType !== ChartType.IDENTITY_BUFF}
+                        onclick={() => (chartType = ChartType.IDENTITY_BUFF)}>
+                        Identity Buffs
+                    </button>
+                    <button
+                        class="rounded-sm px-2 py-1"
+                        class:bg-accent-900={chartType === ChartType.HAT_BUFF}
+                        class:bg-gray-700={chartType !== ChartType.HAT_BUFF}
+                        onclick={() => (chartType = ChartType.HAT_BUFF)}>
+                        Hyper Awakening Technique Buffs
+                    </button>
                 {:else if playerName !== "" && meterState === MeterState.PLAYER}
                     <!--  -->
                 {/if}
@@ -736,6 +842,14 @@
             {:else}
                 <div class="mt-2 h-[300px]" use:chartable={chartOptions} style="width: calc(100vw - 4.5rem);"></div>
             {/if}
+        {:else if chartType === ChartType.BRAND_BUFF}
+            <div class="mt-2 h-[300px]" use:chartable={chartOptions} style="width: calc(100vw - 4.5rem);"></div>
+        {:else if chartType === ChartType.AP_BUFF}
+            <div class="mt-2 h-[300px]" use:chartable={chartOptions} style="width: calc(100vw - 4.5rem);"></div>
+        {:else if chartType === ChartType.IDENTITY_BUFF}
+            <div class="mt-2 h-[300px]" use:chartable={chartOptions} style="width: calc(100vw - 4.5rem);"></div>
+        {:else if chartType === ChartType.HAT_BUFF}
+            <div class="mt-2 h-[300px]" use:chartable={chartOptions} style="width: calc(100vw - 4.5rem);"></div>
         {:else if chartType === ChartType.SKILL_LOG}
             {#if player && player.entityType === EntityType.PLAYER && hasSkillCastLog}
                 <LogSkillChart {chartOptions} {player} encounterDamageStats={encounter.encounterDamageStats} />

--- a/src/lib/encounter.svelte.ts
+++ b/src/lib/encounter.svelte.ts
@@ -103,7 +103,7 @@ export class EncounterState {
 
     partyInfo: PartyInfo | undefined = $state();
 
-    hasAnySkillCastLog = $derived.by(() => {
+    anySkillCastLog = $derived.by(() => {
         return this.players.some((player) => {
             return Object.entries(player.skills).some(([, skill]) => {
                 return skill.skillCastLog && skill.skillCastLog.length > 0;

--- a/src/lib/encounter.svelte.ts
+++ b/src/lib/encounter.svelte.ts
@@ -103,6 +103,14 @@ export class EncounterState {
 
     partyInfo: PartyInfo | undefined = $state();
 
+    hasAnySkillCastLog = $derived.by(() => {
+        return this.players.some((player) => {
+            return Object.entries(player.skills).some(([, skill]) => {
+                return skill.skillCastLog && skill.skillCastLog.length > 0;
+            });
+        });
+    });
+
     constructor(encounter: Encounter | undefined, settings: any, live: boolean = false, colors: any) {
         this.live = live;
         this.encounter = encounter;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -366,7 +366,11 @@ export enum ChartType {
     ROLLING_DPS,
     SKILL_LOG,
     IDENTITY,
-    STAGGER
+    STAGGER,
+    BRAND_BUFF,
+    AP_BUFF,
+    IDENTITY_BUFF,
+    HAT_BUFF
 }
 
 export enum ShieldTab {

--- a/src/lib/utils/buffs.ts
+++ b/src/lib/utils/buffs.ts
@@ -267,7 +267,7 @@ export function calculatePartyWidth(
     return partyWidths;
 }
 
-export function addBardBubbles(key: string, buff: Buff, syn: StatusEffect) {
+export function addBardBubbles(key: string, buff: { bonus?: number }, syn: StatusEffect) {
     if (key.includes("serenadeofcourage")) {
         if (syn.source.desc.includes("15%")) {
             buff.bonus = 15;
@@ -290,7 +290,7 @@ export function addBardBubbles(key: string, buff: Buff, syn: StatusEffect) {
 
 const supportClasses = [classNameToClassId["Paladin"], classNameToClassId["Bard"], classNameToClassId["Artist"]];
 
-function isSupportBuff(statusEffect: StatusEffect) {
+export function isSupportBuff(statusEffect: StatusEffect) {
     if ([2000260, 2000360].includes(statusEffect.uniqueGroup)) {
         return true;
     }
@@ -355,7 +355,7 @@ export const supportSkills = {
     ]
 };
 
-function makeSupportBuffKey(statusEffect: StatusEffect) {
+export function makeSupportBuffKey(statusEffect: StatusEffect) {
     const skillId = statusEffect.source.skill?.id ?? 0;
     let key = "__";
     key += `${classesMap[statusEffect.source.skill?.classId ?? 0]}`;
@@ -394,7 +394,7 @@ const buffCategories = {
     other: ["etc", "arkpassive"]
 };
 
-function isPartySynergy(statusEffect: StatusEffect) {
+export function isPartySynergy(statusEffect: StatusEffect) {
     return (
         buffCategories.partySynergy.includes(statusEffect.buffCategory) &&
         statusEffect.target === StatusEffectTarget.PARTY

--- a/src/lib/utils/supportBuffCharts.ts
+++ b/src/lib/utils/supportBuffCharts.ts
@@ -20,6 +20,8 @@ import { getSkillIcon } from "./strings";
 const partyRegex = /^Party #(\d)$/;
 const partyColors = ['#008000', '#800080', '#87CEEB', '#FFFF00']
 const buffBreakdownTooltipWidth = 120;
+const bardSerenadeOfAmplification = "Serenade of Amplification";
+const artistBlessingOfTheSun = "Blessing of the Sun";
 
 class SupportSynergyDataPoint {
     totalDamage: number;
@@ -95,15 +97,15 @@ interface SupportBuffPoint {
 
 function addStatusEffect(map: Map<string, Map<number, StatusEffect>>, effect: [string, StatusEffect]) {
     const [id, statusEffect] = effect;
-    if (!isPartySynergy(statusEffect) || !isSupportBuff(statusEffect) || statusEffect.source.name === "Serenade of Amplification") {
+    if (!isPartySynergy(statusEffect) || !isSupportBuff(statusEffect) || statusEffect.source.name === bardSerenadeOfAmplification) {
         return;
     }
     const key = makeSupportBuffKey(statusEffect);
-    if (key.includes("Moonfall")) {
+    if (statusEffect.source.name === artistBlessingOfTheSun) {
         return;
     }
     const idNumber = Number(id);
-    groupedSynergiesAdd(map, key, idNumber, statusEffect, null, true);
+    groupedSynergiesAdd(map, key, idNumber, statusEffect, undefined, true);
 }
 
 export function getSupportSynergiesOverTime(

--- a/src/lib/utils/supportBuffCharts.ts
+++ b/src/lib/utils/supportBuffCharts.ts
@@ -1,0 +1,371 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+    EntityType,
+    type Encounter,
+    type Entity,
+    type StatusEffect,
+    type PartyInfo,
+    type SkillHit
+} from "$lib/types";
+import { defaultOptions } from "./charts";
+import {
+    abbreviateNumber,
+    formatDurationFromMs,
+    round
+} from "./numbers";
+import { isPartySynergy, isSupportBuff, makeSupportBuffKey, supportSkills, hyperAwakeningIds, groupedSynergiesAdd, addBardBubbles } from "./buffs";
+import { bossHpMap } from "$lib/constants/bossHpBars";
+import { getSkillIcon } from "./strings";
+
+const partyRegex = /^Party #(\d)$/;
+const partyColors = ['#008000', '#800080', '#87CEEB', '#FFFF00']
+
+class SupportSynergyDataPoint {
+    totalDamage: number;
+    buffs: Map<string, Array<SupportBuffPoint>>;
+
+    constructor() {
+        this.totalDamage = 0;
+        this.buffs = new Map<string, Array<SupportBuffPoint>>();
+    }
+
+    add(hit: SkillHit, key: string, id: number, effect: StatusEffect) {
+        const buffPoints = this.buffs.get(key) || [];
+        let index = buffPoints.findIndex((b) => b.id === id);
+        let buffPoint: SupportBuffPoint = {
+            id: id,
+            bonus: 0,
+            buffedDamage: 0,
+            totalDamage: hit.damage,
+            icon: effect.source.icon,
+            sourceIcon: effect.source.skill?.icon,
+        }
+        if (index !== -1) {
+            buffPoint = buffPoints[index];
+            buffPoint.totalDamage += hit.damage;
+        }
+        addBardBubbles(key, buffPoint, effect);
+        if (hit.buffedBy.includes(id) || hit.debuffedBy.includes(id)) {
+            buffPoint.buffedDamage += hit.damage;
+        }
+        if (index !== -1) {
+            buffPoints[index] = buffPoint;
+        } else {
+            buffPoints.push(buffPoint);
+        }
+        this.buffs.set(key, buffPoints);
+    }
+
+    merge(other: SupportSynergyDataPoint) {
+        const keys = new Set([...this.buffs.keys(), ...other.buffs.keys()]);
+        let totalDamage = 0
+        for (const key of keys) {
+            const buffPointsA = this.buffs.get(key) || [];
+            const buffPointsB = other.buffs.get(key) || [];
+            const buffPointsIds = new Set([...buffPointsA.map((b) => b.id), ...buffPointsB.map((b) => b.id)]);
+            const result = new Array<SupportBuffPoint>();
+            for (const buffPointId of buffPointsIds) {
+                const a = buffPointsA.find((bp) => bp.id === buffPointId) || {} as SupportBuffPoint;
+                const b = buffPointsB.find((bp) => bp.id === buffPointId) || {} as SupportBuffPoint;
+                totalDamage = (a.totalDamage || 0) + (b.totalDamage || 0);
+                result.push({
+                    id: a.id || b.id,
+                    bonus: a.bonus || b.bonus,
+                    totalDamage: totalDamage,
+                    buffedDamage: (a.buffedDamage || 0) + (b.buffedDamage || 0),
+                    icon: a.icon || b.icon,
+                    sourceIcon: a.sourceIcon || b.sourceIcon,
+                })
+            }
+            this.buffs.set(key, result);
+        }
+        this.totalDamage = totalDamage;
+    }
+}
+
+interface SupportBuffPoint {
+    id: number;
+    bonus?: number;
+    buffedDamage: number
+    totalDamage: number
+    icon: string;
+    sourceIcon?: string;
+}
+
+function addStatusEffect(map: Map<string, Map<number, StatusEffect>>, effect: [string, StatusEffect]) {
+    const [id, statusEffect] = effect;
+    if (!isPartySynergy(statusEffect) || !isSupportBuff(statusEffect) || statusEffect.source.name === "Serenade of Amplification") {
+        return;
+    }
+    const key = makeSupportBuffKey(statusEffect);
+    const idNumber = Number(id);
+    groupedSynergiesAdd(map, key, idNumber, statusEffect, null, true);
+}
+
+export function getSupportSynergiesOverTime(
+    encounter: Encounter,
+    entities: Entity[],
+    encounterPartyInfo: PartyInfo,
+    fightStartMs: number,
+    fightEndMs: number,
+    intervalMs: number,
+    legendNames: string[],
+) {
+    const groupedSupportSynergies = new Map<string, Map<number, StatusEffect>>();
+    Object.entries(encounter.encounterDamageStats.buffs)
+        .forEach((effect) => addStatusEffect(groupedSupportSynergies, effect));
+    Object.entries(encounter.encounterDamageStats.debuffs)
+        .forEach((effect) => addStatusEffect(groupedSupportSynergies, effect));
+
+    const parties = new Array<Array<Entity>>();
+    const partyInfo = Object.entries(encounterPartyInfo);
+    if (partyInfo.length >= 2) {
+        for (const [partyIdStr, names] of partyInfo) {
+            const partyId = Number(partyIdStr);
+            parties[partyId] = [];
+            for (const name of names) {
+                const player = entities.find((player) => player.entityType === EntityType.PLAYER && player.name === name);
+                if (player) {
+                    parties[partyId].push(player);
+                }
+            }
+            if (parties[partyId] && parties[partyId].length > 0) {
+                parties[partyId].sort((a, b) => b.damageStats.damageDealt - a.damageStats.damageDealt);
+            }
+        }
+    } else {
+        parties[0] = entities;
+    }
+
+    const partyBuffs = new Array<Map<number, SupportSynergyDataPoint>>();
+    const partyGroupedSupportSynergies = new Map<string, Set<string>>();
+    if (groupedSupportSynergies.size > 0 && parties.length >= 1) {
+        parties.forEach((party, partyId) => {
+            partyGroupedSupportSynergies.set(partyId.toString(), new Set<string>());
+            const partySyns = new Set<string>();
+            for (const player of party) {
+                groupedSupportSynergies.forEach((synergies, key) => {
+                    synergies.forEach((_, id) => {
+                        if (player.damageStats.buffedBy[id] || player.damageStats.debuffedBy[id]) {
+                            partySyns.add(key);
+                        }
+                    });
+                });
+            }
+            partyGroupedSupportSynergies.set(partyId.toString(), new Set([...partySyns].sort()));
+        });
+
+        parties.forEach((party, partyId) => {
+            partyBuffs[partyId] = new Map<number, SupportSynergyDataPoint>();
+
+            partyGroupedSupportSynergies.get(partyId.toString())?.forEach((key) => {
+                const buffs = groupedSupportSynergies.get(key);
+
+                if (!buffs) {
+                    return;
+                }
+
+                let isHat = false;
+
+                buffs.forEach((syn, id) => {
+                    if (supportSkills.haTechnique.includes(id)) {
+                        isHat = true;
+                    }
+
+                    for (const player of party) {
+                        const skills = player.skills;
+                        for (const skill of Object.values(skills)) {
+                            if (!isHat && hyperAwakeningIds.has(skill.id)) {
+                                continue;
+                            }
+                            for (const skillCast of skill.skillCastLog) {
+                                for (const hit of skillCast.hits) {
+                                    const synergyPoint = partyBuffs[partyId].get(hit.timestamp) || new SupportSynergyDataPoint();
+                                    synergyPoint.add(hit, key, id, syn);
+                                    partyBuffs[partyId].set(hit.timestamp, synergyPoint);
+                                }
+                            }
+                        }
+                    }
+                });
+            });
+        });
+    }
+
+    const partySupportSynergyTimeline = new Array<Array<[number, SupportSynergyDataPoint]>>;
+    for (const map of partyBuffs) {
+        partySupportSynergyTimeline.push([...map.entries()].sort((a, b) => a[0] - b[0]));
+    }
+    const supportSynergiesOverTime = new Array<Array<[string, SupportSynergyDataPoint]>>;
+    partySupportSynergyTimeline.map((partyTimeline, partyId) => {
+        let synergyPoint = new SupportSynergyDataPoint();
+        supportSynergiesOverTime[partyId] = [];
+        legendNames.push(`Party #${partyId + 1}`);
+        for (let t = 0, index = 0; t <= fightEndMs - fightStartMs; t += intervalMs) {
+            while (index < partyTimeline.length && partyTimeline[index][0] <= t) {
+                synergyPoint.merge(partyTimeline[index][1]);
+                index++;
+            }
+            const copy = new SupportSynergyDataPoint();
+            copy.merge(synergyPoint);
+            supportSynergiesOverTime[partyId].push([formatDurationFromMs(t), copy]);
+        }
+    });
+
+    return supportSynergiesOverTime.map((data, partyId) => {
+        return {
+            name: legendNames[partyId],
+            color: partyColors[partyId],
+            type: "line",
+            data: data,
+            showSymbol: false,
+            smooth: 0.1,
+            markPoint: {},
+            yAxisIndex: 1
+        }
+    });
+}
+
+export function getSupportSynergiesOverTimeChart(
+    legendNames: string[],
+    chartBuffs: any[],
+    buffSubstring: string,
+    chartBosses: any[],
+    iconPath: string
+) {
+
+    const buffSeries = chartBuffs.map(chartOptions => {
+        return {
+            ...chartOptions,
+            data: chartOptions.data.map((dataPoint: [string, SupportSynergyDataPoint]) => {
+                const time = dataPoint[0];
+                const synergies: SupportSynergyDataPoint = dataPoint[1];
+                for (let [key, buffs] of synergies.buffs) {
+                    if (key.includes(buffSubstring)) {
+                        const buffedDamage = buffs.reduce((sum, buff) => buff.buffedDamage + sum, 0);
+                        return [time, buffedDamage / synergies.totalDamage * 100];
+                    }
+                }
+                return [time, 0];
+            })
+        }
+    });
+
+    return {
+        ...defaultOptions,
+        legend: {
+            data: legendNames,
+            textStyle: {
+                color: "white"
+            },
+            type: "scroll",
+            width: "90%",
+            pageIconInactiveColor: "#313131",
+            pageIconColor: "#aaa",
+            pageTextStyle: {
+                color: "#aaa"
+            },
+            selector: true
+        },
+        tooltip: {
+            trigger: "axis",
+            formatter: function (params: any[]) {
+                const time = params[0].name;
+                const bossTooltips = new Array<string>();
+                const buffToolTips = new Array<string>();
+                params.forEach((param) => {
+                    let label: string = param.seriesName;
+                    let value = param.value[1];
+                    let partyNumber = partyRegex.exec(label);
+                    if (partyNumber) {
+                        const partyId = parseInt(partyNumber[1]) - 1;
+                        const synergies: SupportSynergyDataPoint = chartBuffs[partyId].data[param.dataIndex][1];
+                        let buffBreakdown = "<div>";
+                        synergies.buffs.forEach((buffPoint, key) => {
+                            if (key.includes(buffSubstring)) {
+                                for (const buff of buffPoint) {
+                                    const buffedDamage = round(buff.buffedDamage / buff.totalDamage * 100);
+                                    if (buffedDamage === "0.0") {
+                                        continue;
+                                    }
+                                    if (buffBreakdown.length > 5) {
+                                        buffBreakdown += " + ";
+                                    }
+                                    if (buff.sourceIcon) {
+                                        buffBreakdown += `<img src=${iconPath + getSkillIcon(buff.sourceIcon)} alt="buff_source_icon" class="size-5 rounded mr-1"/>`;
+                                        if (buff.bonus) {
+                                            buffBreakdown += `[${buff.bonus}%] `;
+                                        }
+                                    } else {
+                                        buffBreakdown += `<img src=${iconPath + getSkillIcon(buff.icon)} alt="buff_icon" class="size-5 rounded mr-1"/>`;
+                                    }
+                                    buffBreakdown += `${buffedDamage}%`;
+                                }
+                            }
+                        });
+                        buffBreakdown += "</div>"
+                        value = round(value);
+                        label =
+                            `<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;background-color:${param.color}"></span>` +
+                            label;
+                        buffToolTips.push(
+                            `<div style="display:flex; justify-content: space-between;">
+                                <div>${label}</div> ${buffBreakdown} <div style="">${value}%</div>
+                            </div>`
+                        )
+                    } else {
+                        value += "%";
+                        if (Object.hasOwn(bossHpMap, label)) {
+                            const bossMaxHpBars = bossHpMap[label];
+                            const bossHpBars = Math.floor(bossMaxHpBars * (parseFloat(value) / 100));
+                            value = `${bossHpBars}x (${value})`;
+                        }
+                        bossTooltips.push(
+                            `<div style="display:flex; justify-content: space-between;"><div style="padding-right: 1rem;font-weight: 600;">${label}</div><div style="font-weight: 600;">${value}</div></div>`
+                        )
+                    }
+                });
+                return `<div>${time}</div><div style="min-width: 32rem;">${bossTooltips.join("")}${buffToolTips.join("")}</div>`;
+            }
+        },
+        xAxis: {
+            type: "category",
+            splitLine: {
+                show: false
+            },
+            data: chartBuffs[0].data.map((d: [number, SupportSynergyDataPoint]) => d[0]),
+            boundaryGap: false,
+            axisLabel: {
+                color: "white"
+            }
+        },
+        yAxis: [
+            {
+                type: "value",
+                splitLine: {
+                    show: true,
+                    lineStyle: {
+                        color: "#333"
+                    }
+                },
+                axisLabel: {
+                    color: "white",
+                    formatter: function (value: number) {
+                        return abbreviateNumber(value);
+                    }
+                }
+            },
+            {
+                type: "value",
+                splitLine: {
+                    show: false
+                },
+                axisLabel: {
+                    color: "white",
+                    formatter: "{value}%"
+                }
+            }
+        ],
+        series: [...buffSeries, ...chartBosses]
+    };
+}


### PR DESCRIPTION
Add Support Buffs Overtime (similar to Avg DPS)

Overview
- Buffed Damage/Total Damage is collected into 5 second intervals similar to average DPS, then buffed percentage is displayed over time for the whole raid duration.
- Buffs are shown for each party not attributed to a specific support player.
- Tooltip shows buffed breakdown.
- Legend colors are similar to in-game party colors (Party 1 → Green, Party 2 → Purple, Party 3 → Light Blue, Party 4 → Yellow-ish). Not exact color codes as the game is used, that could be improved/changed if needed.
- This is enabled by default and has no flag/setting. Let me know if you'd like me to change this.
- Individual tabs will not exist if there are no corresponding buff casts for any party.
- All tabs will not exist if there are no `skillCastLog`

Notes
- ~Buff icons in the tooltip are misaligned (see attached image)~
- ~Tabs are always shown and will display 0% over time for the below cases~
  - ~There aren't support in the parties~
  - ~Supports didn't cast their buffs~
  - ~Old encounters when support didn't have T-skill~

Limitations
- ~If some players don't have `skillCastLog` the data would be inaccurate/wrong. Let me know if you'd like me to handle this.~

![Example](https://github.com/user-attachments/assets/b6788040-32a1-4403-b9b7-9106be5007d6)

![buff-alignment](https://github.com/user-attachments/assets/acf5d20f-967d-40b8-9aaf-ff6454d6cf1d)