### PR TITLE
Fix searching by ivory tower hanging forever

### DIFF
--- a/src/lib/constants/encounters.ts
+++ b/src/lib/constants/encounters.ts
@@ -35,7 +35,7 @@ export const encounterMap: { [key: string]: { [key: string]: Array<string> } } =
         "Akkan G2": ["Lord of Degradation Akkan"],
         "Akkan G3": ["Plague Legion Commander Akkan", "Lord of Kartheon Akkan"]
     },
-    Ivory: {
+    "Ivory Tower": {
         "Ivory Tower G1": ["Kaltaya, the Blooming Chaos"],
         "Ivory Tower G2": ["Rakathus, the Lurking Arrogance"],
         "Ivory Tower G3": ["Firehorn, Trampler of Earth"],


### PR DESCRIPTION
When filtering encounters by Ivory Tower the page load forever. (Found by https://discord.com/channels/1174544914139328572/1196224567337824406/1369823605306822757)

This happened because in `loadEncounters` we try to index `encounterMap` with `"Ivory Tower"` but so such key exist.
An exception gets thrown and the load appears to take forever.
```
  async function loadEncounters(
      searchFilter: SearchFilter,
      search: string,
      page: number
  ): Promise<Array<EncounterPreview>> {
      NProgress.start();
      let raidBosses = Array.from(searchFilter.bosses);
      if (searchFilter.encounters.size > 0) {
          for (const encounter of searchFilter.encounters) {
              const raid = encounter.substring(0, encounter.lastIndexOf(" "));
              raidBosses.push(...encounterMap[raid][encounter]);
          }
      }
```
I renamed `"Ivory"` to `"Ivory Tower"` in `encounters.ts` to fix this.