### PR TITLE
Set minimum WebView2 version

### DIFF
--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -14,7 +14,8 @@
       "timestampUrl": "",
       "nsis": {
         "template": "./nsis/installer.nsi",
-        "installerIcon": "icons/icon.ico"
+        "installerIcon": "icons/icon.ico",
+        "minimumWebview2Version": "119.0.2151.97"
       }
     },
     "targets": [


### PR DESCRIPTION
Uses [Minimum Webview2 version](https://v2.tauri.app/distribute/windows-installer/#minimum-webview2-version) to update it if needed

<details> 
  <summary>✓ <a href="https://github.com/westinyang/WebView2RuntimeArchive/releases/tag/119.0.2151.97">119.0.2151.97</a></summary>
  
  <img width="1094" height="998" alt="119" src="https://github.com/user-attachments/assets/4aedace2-d59e-47e4-b629-b79d87c93c6e" />
</details>
<details> 
  <summary>✕ <a href="https://github.com/westinyang/WebView2RuntimeArchive/releases/tag/118.0.2088.76">118.0.2088.76</a></summary>
  
  <img width="1094" height="998" alt="118" src="https://github.com/user-attachments/assets/c965aad5-3431-4f03-8014-4fd887b7d103" />
</details>
<details> 
  <summary>✕ <a href="https://github.com/westinyang/WebView2RuntimeArchive/releases/tag/95.0.1020.53">95.0.1020.53</a></summary>
  
  <img width="1094" height="998" alt="95" src="https://github.com/user-attachments/assets/5896f0f8-da8d-414d-9050-8a8087e19a6f" />
</details>

Originally I wanted to show a dialog box when webview is missing, but it turns out tauri v2 already [handles that](https://github.com/user-attachments/assets/9c0701d0-c87e-47f4-a837-6f63d41a985b). I also tried showing dialog on panic, but it's bugged on linux