### PR TITLE
Feat split modules

### DIFF
--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -1,0 +1,69 @@
+#![allow(dead_code)]
+
+use anyhow::Result;
+use tokio::task::JoinHandle;
+use std::{path::PathBuf, sync::{atomic::AtomicBool, Arc}};
+use log::*;
+use tauri::AppHandle;
+
+use crate::settings::Settings;
+
+pub struct BackgroundWorkerArgs {
+    pub app_handle: AppHandle,
+    pub update_checked: Arc<AtomicBool>,
+    pub port: u16,
+    pub region_file_path: PathBuf,
+    pub settings: Option<Settings>,
+    pub version: String
+}
+
+pub struct BackgroundWorker(Option<JoinHandle<Result<()>>>);
+
+impl BackgroundWorker {
+    pub fn new() -> Self {
+        Self(None)
+    }
+
+    pub fn start(&mut self, args: BackgroundWorkerArgs) -> Result<()> {
+      
+        let handle = tokio::task::spawn_blocking(move || Self::inner(args));
+
+        self.0 = Some(handle);
+
+        Ok(())
+    }
+
+    fn inner(args: BackgroundWorkerArgs) -> Result<()> {
+        let BackgroundWorkerArgs {
+            app_handle,
+            update_checked,
+            port,
+            region_file_path,
+            settings,
+            version
+        } = args;
+        
+        #[cfg(feature = "meter-core")]
+        {
+            use std::sync::atomic::Ordering;
+
+            use crate::live;
+
+            while !update_checked.load(Ordering::Relaxed) {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            
+            info!("listening on port: {port}");
+            
+            live::start(app_handle, port, settings).map_err(|e| {
+                error!("unexpected error occurred in parser: {e}");
+            });
+        }
+
+        Ok(())
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.0.as_ref().is_some_and(|handle| !handle.is_finished())
+    }
+}

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -11,6 +11,7 @@ pub const METER_WINDOW_LABEL: &str = "main";
 pub const METER_MINI_WINDOW_LABEL: &str = "mini";
 pub const LOGS_WINDOW_LABEL: &str = "logs";
 pub const DATABASE_PATH: &str = "encounters.db";
+pub const MIGRATIONS_PATH: &str = "migrations";
 pub const SETTINGS_PATH: &str = "settings.json";
 pub const LOCAL_PLAYERS_PATH: &str = "local_players.json";
 pub const REGION_PATH: &str = "current_region";

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -8,29 +8,34 @@ use crate::constants::*;
 
 #[derive(Debug, Clone)]
 pub struct AppContext {
+    pub version: String,
     pub app_path: PathBuf,
     pub current_dir: PathBuf,
     pub settings_path: PathBuf,
     pub database_path: PathBuf,
+    pub migrations_path: PathBuf,
     pub local_player_path: PathBuf,
     pub region_file_path: PathBuf,
 }
 
 impl AppContext {
-    pub fn new() -> Result<Self> {
+    pub fn new(version: String) -> Result<Self> {
 
         let app_path = std::env::current_exe()?;
         let current_dir = app_path.parent().unwrap().to_path_buf();
         let settings_path = current_dir.join(SETTINGS_PATH);
         let database_path = current_dir.join(DATABASE_PATH);
+        let migrations_path = current_dir.join(MIGRATIONS_PATH);
         let local_player_path = current_dir.join(LOCAL_PLAYERS_PATH);
         let region_file_path = current_dir.join(REGION_PATH);
 
         Ok(Self {
+            version,
             app_path,
             current_dir,
             settings_path,
             database_path,
+            migrations_path,
             local_player_path,
             region_file_path
         })

--- a/src-tauri/src/live/encounter_state.rs
+++ b/src-tauri/src/live/encounter_state.rs
@@ -1,7 +1,7 @@
 use crate::get_db_connection;
 use crate::data::*;
 use crate::live::entity_tracker::{Entity, EntityTracker};
-use crate::live::skill_tracker::{CastEvent, SkillTracker};
+use crate::live::skill_tracker::SkillTracker;
 use crate::live::stats_api::StatsApi;
 use crate::live::status_tracker::StatusEffectDetails;
 use crate::live::utils::*;

--- a/src-tauri/src/live/skill_tracker.rs
+++ b/src-tauri/src/live/skill_tracker.rs
@@ -1,4 +1,4 @@
-use crate::models::{SkillCast, SkillHit};
+use crate::models::{CastEvent, SkillCast, SkillHit};
 use hashbrown::HashMap;
 use moka::sync::Cache;
 use std::collections::BTreeMap;
@@ -122,10 +122,4 @@ impl SkillTracker {
 
         cast_log
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct CastEvent {
-    pub timestamp: i64,
-    pub cooldown_duration_ms: i64,
 }

--- a/src-tauri/src/live/utils.rs
+++ b/src-tauri/src/live/utils.rs
@@ -1,7 +1,7 @@
 use crate::constants::DB_VERSION;
 use crate::data::*;
 use crate::live::entity_tracker::Entity;
-use crate::live::skill_tracker::{CastEvent, SkillTracker};
+use crate::live::skill_tracker::SkillTracker;
 use crate::live::stats_api::InspectInfo;
 use crate::live::status_tracker::StatusEffectDetails;
 use crate::models::*;
@@ -1661,11 +1661,4 @@ fn get_damage_without_hyper_or_special(e: &EncounterEntity) -> i64 {
         .map(|s| s.total_damage)
         .sum::<i64>();
     e.damage_stats.damage_dealt - hyper - special
-}
-
-struct SupportBuffs {
-    brand: f64,
-    buff: f64,
-    identity: f64,
-    hyper: f64,
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,6 +10,11 @@ mod data;
 mod models;
 mod settings;
 mod local;
+mod ui;
+mod shell;
+mod utils;
+mod setup;
+mod background;
 
 use anyhow::Result;
 use flate2::read::GzDecoder;
@@ -43,8 +48,8 @@ use crate::settings::{Settings, SettingsManager};
 async fn main() -> Result<()> {
     let _ = app::logger::init()?;
     let tauri_context = tauri::generate_context!();
-    let context = AppContext::new()?;
     let package_info = tauri_context.package_info();
+    let context = AppContext::new(package_info.version.to_string())?;
     let settings_manager = SettingsManager::new(context.settings_path).expect("could not create settings");
     load_windivert(&context.current_dir).expect("could not load windivert dependencies");
     // load meter-data

--- a/src-tauri/src/models/encounter.rs
+++ b/src-tauri/src/models/encounter.rs
@@ -1,6 +1,7 @@
 use hashbrown::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use crate::models::ArkPassiveData;
 use crate::models::Skill;
 
 use crate::models::EntityType;
@@ -77,21 +78,6 @@ pub struct EncounterEntity {
     pub loadout_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub combat_power: Option<f32>,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
-pub struct ArkPassiveData {
-    pub evolution: Option<Vec<ArkPassiveNode>>,
-    pub enlightenment: Option<Vec<ArkPassiveNode>>,
-    pub leap: Option<Vec<ArkPassiveNode>>,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
-pub struct ArkPassiveNode {
-    pub id: u32,
-    pub lv: u8,
 }
 
 #[serde_as]

--- a/src-tauri/src/models/misc.rs
+++ b/src-tauri/src/models/misc.rs
@@ -57,3 +57,66 @@ pub struct EncounterDbInfo {
     pub total_encounters: i32,
     pub total_encounters_filtered: i32,
 }
+
+#[derive(Debug, Clone)]
+pub struct CastEvent {
+    pub timestamp: i64,
+    pub cooldown_duration_ms: i64,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct InspectInfo {
+    pub combat_power: Option<CombatPower>,
+    pub ark_passive_enabled: bool,
+    pub ark_passive_data: Option<ArkPassiveData>,
+    pub engravings: Option<Vec<u32>>,
+    pub gems: Option<Vec<GemData>>,
+    pub loadout_snapshot: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ArkPassiveData {
+    pub evolution: Option<Vec<ArkPassiveNode>>,
+    pub enlightenment: Option<Vec<ArkPassiveNode>>,
+    pub leap: Option<Vec<ArkPassiveNode>>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ArkPassiveNode {
+    pub id: u32,
+    pub lv: u8,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CombatPower {
+    // 1 for dps, 2 for support
+    pub id: u32,
+    pub score: f32,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct GemData {
+    pub tier: u8,
+    pub skill_id: u32,
+    pub gem_type: u8,
+    pub value: u32,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Engraving {
+    pub id: u32,
+    pub level: u8,
+}
+
+pub struct SupportBuffs {
+    pub brand: f64,
+    pub buff: f64,
+    pub identity: f64,
+    pub hyper: f64,
+}

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1,0 +1,139 @@
+use std::{error::Error, sync::{atomic::{AtomicBool, Ordering}, Arc}};
+
+use log::*;
+use tauri::{App, AppHandle, Manager};
+use tauri_plugin_updater::UpdaterExt;
+
+use crate::{background::{BackgroundWorker, BackgroundWorkerArgs}, constants::DEFAULT_PORT, context::AppContext, settings::*, shell::ShellManager, ui::{setup_tray, AppHandleExtensions, WindowExtensions}};
+
+pub fn setup(app: &mut App) -> Result<(), Box<dyn Error>> {
+
+    let app_handle = app.handle();
+
+    let context = app.state::<AppContext>();
+    let shell_manger = ShellManager::new(app_handle.clone(), context.inner().clone());
+    let settings_manager = app.state::<SettingsManager>();
+    
+    info!("starting app v{}", context.version);
+    setup_tray(app_handle)?;
+    let update_checked: Arc<AtomicBool> = check_updates(app_handle);
+
+    let settings = settings_manager.read().expect("Could not read settings");
+
+    let port = initialize_windows_and_settings(
+        &app_handle,
+        settings.as_ref(),
+        &shell_manger
+    );
+
+    app_handle.manage(shell_manger);
+
+    let mut background = BackgroundWorker::new();
+
+    let args = BackgroundWorkerArgs {
+        app_handle: app_handle.clone(),
+        update_checked,
+        port,
+        settings,
+        region_file_path: context.region_file_path.clone(),
+        version: context.version.clone()
+    };
+
+    background.start(args)?;
+    app_handle.manage(background);
+
+    // #[cfg(debug_assertions)]
+    // {
+    //     _logs_window.open_devtools();
+    // }
+
+    Ok(())
+}
+
+fn check_updates(app_handle: &AppHandle) -> Arc<AtomicBool> {
+    let update_checked = Arc::new(AtomicBool::new(false));
+
+    {
+        let update_checked = update_checked.clone();
+        let app_handle = app_handle.clone();
+
+        let check_update = async move {
+            match app_handle.updater().unwrap().check().await {
+                #[cfg(not(debug_assertions))]
+                Ok(Some(update)) => {
+                    info!("update available, downloading update: v{}", update.version);
+
+                    unload_driver();
+                    remove_driver();
+
+                    if let Err(e) = update.download_and_install(|_, _| {}, || {}).await {
+                        error!("failed to download update: {}", e);
+                    }
+                }
+                Err(e) => {
+                    warn!("failed to get update: {e}");
+                    update_checked.store(true, Ordering::Relaxed);
+                }
+                _ => {
+                    info!("no update available");
+                    update_checked.store(true, Ordering::Relaxed);
+                }
+            }
+        };
+
+        tauri::async_runtime::spawn(check_update);
+    }
+
+    update_checked
+}
+
+fn initialize_windows_and_settings(
+    app_handle: &AppHandle,
+    settings: Option<&Settings>,
+    shell_manger: &ShellManager) -> u16 {
+
+    let mut port = DEFAULT_PORT;
+    let meter_window = app_handle.get_meter_window().unwrap();
+    let mini_window = app_handle.get_mini_window().unwrap();
+    let logs_window = app_handle.get_logs_window().unwrap();
+    
+    if let Some(settings) = settings.clone() {
+
+        info!("settings loaded");
+        if settings.general.mini {
+            mini_window.restore_default_state();
+            mini_window.show().unwrap();
+        } else if !settings.general.hide_meter_on_start && !settings.general.mini {
+            meter_window.restore_default_state();
+            meter_window.show().unwrap();
+        }
+        
+        if !settings.general.hide_logs_on_start {
+            logs_window.restore_default_state();
+            logs_window.show().unwrap();
+        }
+
+        if settings.general.always_on_top {
+            meter_window.set_always_on_top(true).unwrap();
+            mini_window.set_always_on_top(true).unwrap();
+        } else {
+            meter_window.set_always_on_top(false).unwrap();
+            mini_window.set_always_on_top(false).unwrap();    
+        }
+
+        if settings.general.auto_iface && settings.general.port > 0 {
+            port = settings.general.port;
+        }
+
+        if settings.general.start_loa_on_start {
+            info!("auto launch game enabled");
+            shell_manger.start_loa_process();
+        }
+    }
+    else {
+        meter_window.show().unwrap();
+        logs_window.show().unwrap();
+    }
+
+    port
+}

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -1,0 +1,75 @@
+use log::*;
+use sysinfo::{ProcessRefreshKind, RefreshKind, System};
+use tauri::AppHandle;
+use tauri_plugin_opener::OpenerExt;
+use tauri_plugin_shell::ShellExt;
+
+use crate::{constants::{GAME_EXE_NAME, STEAM_GAME_URL}, context::AppContext};
+
+pub struct ShellManager(AppHandle, AppContext);
+
+impl ShellManager {
+    pub fn new(shell: AppHandle, context: AppContext) -> Self {
+        Self(shell, context)
+    }
+
+    pub fn open_db_path(&self) {
+        
+        let path = &self.1.database_path;
+        info!("open_db_path: {}", path.display());
+
+        if let Err(err) = self.0.opener().open_path(path.to_str().unwrap(), None::<String>) {
+            error!("Failed to open database path: {}", err);
+        }
+    }
+
+    pub fn start_loa_process(&self) {
+        if self.check_loa_running() {
+            return info!("lost ark already running");
+        }
+
+        info!("starting lost ark process...");
+
+        if let Err(err) = self.0.opener().open_path(STEAM_GAME_URL, None::<String>) {
+            error!("could not open lost ark: {}", err);
+        }
+    }
+
+    pub fn check_loa_running(&self) -> bool {
+        let system = System::new_with_specifics(
+            RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing().without_tasks()),
+        );
+        
+        let process_name = GAME_EXE_NAME;
+
+        system
+            .processes()
+            .values()
+            .any(|p| p.name().eq_ignore_ascii_case(process_name))
+    }
+
+    pub async fn remove_driver(&self) {
+        #[cfg(target_os = "windows")]
+        {
+            use tauri_plugin_shell::ShellExt;
+
+            let command = self.0.shell().command("sc").args(["delete", "windivert"]);
+
+            command.output().await.expect("unable to delete driver");
+        }
+    }
+
+    pub async fn unload_driver(&self) {
+        #[cfg(target_os = "windows")]
+        {  
+            let command = self.0.shell().command("sc").args(["stop", "windivert"]);
+            let result = command.output().await;
+
+            if result.is_ok_and(|output| output.status.success()) {
+                info!("stopped driver");
+            } else {
+                warn!("could not execute command to stop driver");
+            }
+        }
+    }
+}

--- a/src-tauri/src/ui/events.rs
+++ b/src-tauri/src/ui/events.rs
@@ -1,0 +1,145 @@
+use std::str::FromStr;
+
+use log::*;
+use anyhow::Result;
+use tauri::{async_runtime, menu::MenuEvent, tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconEvent}, AppHandle, Manager, Window, WindowEvent};
+use tauri_plugin_window_state::AppHandleExt;
+
+use crate::{constants::*, settings::SettingsManager, shell::ShellManager, ui::{AppHandleExtensions, TrayCommand, WindowExtensions}};
+
+pub fn on_tray_icon_event(tray: &TrayIcon, event: TrayIconEvent) {
+     {
+        if let TrayIconEvent::Click {
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+            ..
+        } = event
+        {
+            let app_handle = tray.app_handle();
+            if let Some(meter) = app_handle.get_meter_window() {
+                meter.restore_and_focus();
+            }
+        }
+    }
+}
+
+pub fn on_menu_event(app: &AppHandle, event: MenuEvent) {
+    if let Err(err) = on_menu_event_inner(app, event) {
+        error!("An error occurred whilst handling menu event {}", err);
+    }
+}
+
+pub fn on_menu_event_inner(app_handle: &AppHandle, event: MenuEvent) -> Result<()> {
+    let menu_item_id = event.id().0.as_str();
+    let settings_manager = app_handle.state::<SettingsManager>();
+
+    match TrayCommand::from_str(menu_item_id)? {
+        TrayCommand::Quit => {
+            app_handle.save_window_state(WINDOW_STATE_FLAGS)?;
+            
+            let shell_manager = app_handle.state::<ShellManager>();
+            async_runtime::block_on(async {
+                shell_manager.unload_driver().await;
+            });
+        
+            app_handle.exit(0);
+        }
+        TrayCommand::Hide => {
+            if let Some(meter) = app_handle.get_meter_window() {
+                meter.hide()?;
+            }
+
+            if let Some(mini) = app_handle.get_mini_window() {
+                mini.hide()?;
+            }
+        }
+        TrayCommand::ShowMeter => {
+            let settings_manager = app_handle.state::<SettingsManager>();
+            let settings = settings_manager.read()?.unwrap_or_default();
+            let window = app_handle.get_window(settings.general.mini);
+            window.restore_and_focus();
+        }
+        TrayCommand::Reset => {
+            let settings = settings_manager.read()?.unwrap_or_default();
+
+            if settings.general.mini {
+                if let Some(mini) = app_handle.get_mini_window() {
+                    mini.set_size(DEFAULT_MINI_METER_WINDOW_SIZE)?;
+                    mini.set_position(WINDOW_POSITION)?;
+                    mini.restore_and_focus();
+                }
+
+                return Ok(())
+            }
+
+            if let Some(meter) = app_handle.get_meter_window() {
+                meter.set_size(DEFAULT_METER_WINDOW_SIZE)?;
+                meter.set_position(WINDOW_POSITION)?;
+                meter.restore_and_focus();
+            }
+        }
+        TrayCommand::ShowLogs => {
+            if let Some(logs) = app_handle.get_logs_window() {
+                logs.show().unwrap();
+                logs.unminimize().unwrap();
+            }
+        }
+        TrayCommand::StartLoa => {
+            let shell_manager = app_handle.state::<ShellManager>();
+            shell_manager.start_loa_process();
+        }
+    }
+
+    Ok(())
+}
+
+pub fn on_window_event(window: &Window, event: &WindowEvent) {
+    let label = window.label();
+    on_window_event_inner(label, window, event).expect("An error occurred whilst handling window event");
+}
+
+pub fn on_window_event_inner(label: &str, window: &Window, event: &WindowEvent) -> Result<()> {
+    match event {
+        WindowEvent::CloseRequested { api, .. } => {
+            api.prevent_close();
+
+            if label == LOGS_WINDOW_LABEL {
+                window.hide()?;
+
+                return Ok(())
+            }
+
+            let app_handle = window.app_handle();
+            let meter_window = app_handle.get_meter_window().unwrap();
+            let logs_window = app_handle.get_logs_window().unwrap();
+
+            if logs_window.is_minimized()? {
+                logs_window.unminimize()?;
+            }
+
+            if meter_window.is_minimized()? {
+                meter_window.unminimize()?;
+            } 
+
+            let shell_manager = app_handle.state::<ShellManager>();
+            async_runtime::block_on(async {
+                shell_manager.unload_driver().await;
+            });
+
+            app_handle.exit(0);
+
+            Ok(())
+        },
+        WindowEvent::Focused(focused) => {
+            if *focused {
+                return Ok(())
+            }
+
+            let app_handle = window.app_handle();
+            app_handle.save_window_state(WINDOW_STATE_FLAGS)?;
+
+            Ok(())
+        },
+        _ => Ok(()),
+    }
+}

--- a/src-tauri/src/ui/extensions.rs
+++ b/src-tauri/src/ui/extensions.rs
@@ -1,0 +1,125 @@
+use std::ops::Deref;
+
+use tauri::{AppHandle, Manager, WebviewWindow};
+use tauri_plugin_window_state::WindowExt;
+
+use crate::constants::{LOGS_WINDOW_LABEL, METER_MINI_WINDOW_LABEL, METER_WINDOW_LABEL, WINDOW_STATE_FLAGS};
+
+pub trait AppHandleExtensions {
+    fn get_meter_window(&self) -> Option<MeterWindow>;
+    fn get_mini_window(&self) -> Option<OtherWindow>;
+    fn get_logs_window(&self) -> Option<OtherWindow>;
+    fn get_window(&self, is_mini: bool) -> Box<dyn WindowExtensions>;
+}
+
+pub trait WindowExtensions {
+    fn restore_default_state(&self);
+    fn restore_and_focus(&self);
+}
+
+impl AppHandleExtensions for AppHandle {
+    fn get_logs_window(&self) -> Option<OtherWindow> {
+        self.get_webview_window(LOGS_WINDOW_LABEL).map(OtherWindow::new)
+    }
+    
+    fn get_meter_window(&self) -> Option<MeterWindow> {
+        self.get_webview_window(METER_WINDOW_LABEL).map(MeterWindow::new)
+    }
+    
+    fn get_mini_window(&self) -> Option<OtherWindow> {
+        self.get_webview_window(METER_MINI_WINDOW_LABEL).map(OtherWindow::new)
+    }
+    
+    fn get_window(&self, is_mini: bool) -> Box<dyn WindowExtensions> {
+        let window = if is_mini {
+            Box::new(self.get_mini_window().unwrap()) as Box<dyn WindowExtensions>
+        } else {
+            Box::new(self.get_meter_window().unwrap()) as Box<dyn WindowExtensions>
+        };
+
+        window
+    }
+}
+
+impl AppHandleExtensions for &AppHandle {
+    fn get_logs_window(&self) -> Option<OtherWindow> {
+        self.get_webview_window(LOGS_WINDOW_LABEL).map(OtherWindow::new)
+    }
+    
+    fn get_meter_window(&self) -> Option<MeterWindow> {
+        self.get_webview_window(METER_WINDOW_LABEL).map(MeterWindow::new)
+    }
+    
+    fn get_mini_window(&self) -> Option<OtherWindow> {
+        self.get_webview_window(METER_MINI_WINDOW_LABEL).map(OtherWindow::new)
+    }
+
+    fn get_window(&self, is_mini: bool) -> Box<dyn WindowExtensions> {
+        let window = if is_mini {
+            Box::new(self.get_mini_window().unwrap()) as Box<dyn WindowExtensions>
+        } else {
+            Box::new(self.get_meter_window().unwrap()) as Box<dyn WindowExtensions>
+        };
+
+        window
+    }
+}
+
+pub struct MeterWindow(WebviewWindow);
+
+impl WindowExtensions for MeterWindow {
+    fn restore_and_focus(&self) {
+        unsafe {
+            self.0.show().unwrap_unchecked();
+            self.0.unminimize().unwrap_unchecked();
+            self.0.set_focus().unwrap_unchecked();
+            self.0.set_ignore_cursor_events(false).unwrap_unchecked();
+        }
+    }
+    
+    fn restore_default_state(&self) {
+        unsafe { self.0.restore_state(WINDOW_STATE_FLAGS).unwrap_unchecked() }
+    }
+}
+
+impl MeterWindow {
+    pub fn new(window: WebviewWindow) -> Self {
+        Self(window)
+    }
+}
+
+impl Deref for MeterWindow {
+    type Target = WebviewWindow;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct OtherWindow(WebviewWindow);
+
+impl WindowExtensions for OtherWindow {
+    fn restore_and_focus(&self) {
+        unsafe {
+            self.0.show().unwrap_unchecked();
+            self.0.unminimize().unwrap_unchecked();
+            self.0.set_focus().unwrap_unchecked();
+        }
+    }
+    
+    fn restore_default_state(&self) {
+        unsafe { self.0.restore_state(WINDOW_STATE_FLAGS).unwrap_unchecked() }
+    }
+}
+
+impl OtherWindow {
+    pub fn new(window: WebviewWindow) -> Self {
+        Self(window)
+    }
+}
+
+impl Deref for OtherWindow {
+    type Target = WebviewWindow;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src-tauri/src/ui/mod.rs
+++ b/src-tauri/src/ui/mod.rs
@@ -1,0 +1,7 @@
+pub mod tray;
+pub mod extensions;
+pub mod events;
+
+pub use tray::*;
+pub use extensions::*;
+pub use events::*;

--- a/src-tauri/src/ui/tray.rs
+++ b/src-tauri/src/ui/tray.rs
@@ -1,0 +1,74 @@
+use anyhow::anyhow;
+use strum::EnumProperty;
+use strum_macros::{AsRefStr, EnumProperty, EnumString};
+use tauri::{menu::{Menu, MenuBuilder}, AppHandle, Runtime};
+
+use crate::{constants::*, ui::{on_menu_event, on_tray_icon_event}};
+
+#[derive(Debug, EnumString, EnumProperty, AsRefStr)]
+#[strum(serialize_all = "kebab_case")]
+pub enum TrayCommand {
+    #[strum(props(label = "Show Logs"))]
+    ShowLogs,
+
+    #[strum(props(label = "Show Meter"))]
+    ShowMeter,
+
+    #[strum(props(label = "Hide Meter"))]
+    Hide,
+
+    #[strum(props(label = "Start Lost Ark"))]
+    StartLoa,
+
+    #[strum(props(label = "Reset Window"))]
+    Reset,
+
+    #[strum(props(label = "Quit"))]
+    Quit,
+}
+
+pub struct LoaMenuBuilder<'a, R: Runtime>(
+    MenuBuilder<'a, R, AppHandle<R>>
+);
+
+impl<'a, R: Runtime> LoaMenuBuilder<'a, R> {
+    pub fn new(app: &'a AppHandle<R>) -> Self {
+        Self(MenuBuilder::new(app))
+    }
+
+    pub fn command(mut self, cmd: TrayCommand) -> Self {
+        self.0 = self.0.text(cmd.as_ref(), cmd.get_str("label").unwrap());
+        self
+    }
+
+    pub fn separator(mut self) -> Self {
+        self.0 = self.0.separator();
+        self
+    }
+
+    pub fn build(self) -> tauri::Result<Menu<R>> {
+        self.0.build()
+    }
+}
+
+pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
+     let menu = LoaMenuBuilder::new(app)
+        .command(TrayCommand::ShowLogs)
+        .separator()
+        .command(TrayCommand::ShowMeter)
+        .command(TrayCommand::Hide)
+        .separator()
+        .command(TrayCommand::StartLoa)
+        .separator()
+        .command(TrayCommand::Reset)
+        .separator()
+        .command(TrayCommand::Quit)
+        .build()?;
+
+    let tray = app.tray_by_id(METER_WINDOW_LABEL).ok_or_else(|| anyhow!("Could not find main window"))?;
+    tray.set_menu(Some(menu))?;
+    tray.on_menu_event(on_menu_event);
+    tray.on_tray_icon_event(on_tray_icon_event);
+
+    Ok(())
+}

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,0 +1,131 @@
+#![allow(dead_code)]
+
+use crate::models::{ArkPassiveNode, EncounterEntity};
+
+pub fn is_support(entity: &EncounterEntity) -> bool {
+    if let Some(spec) = &entity.spec {
+        is_support_spec(spec)
+    } else {
+        is_support_class(&entity.class_id)
+    }
+}
+
+pub fn is_support_class(class_id: &u32) -> bool {
+    matches!(class_id, 105 | 204 | 602 | 113)
+}
+
+pub fn is_support_spec(spec: &str) -> bool {
+    matches!(
+        spec,
+        "Desperate Salvation" | "Full Bloom" | "Blessed Aura" | "Liberator"
+    )
+}
+
+pub fn get_spec_from_ark_passive(node: &ArkPassiveNode) -> String {
+    match node.id {
+        2160000 => "Berserker Technique",
+        2160010 => "Mayhem",
+        2170000 => "Lone Knight",
+        2170010 => "Combat Readiness",
+        2180000 => "Rage Hammer",
+        2180010 => "Gravity Training",
+        2360000 => "Judgment",
+        2360010 => "Blessed Aura",
+        2450000 => "Punisher",
+        2450010 => "Predator",
+        2480000 => "Shining Knight",
+        2480100 => "Liberator",
+        2230000 => "Ultimate Skill: Taijutsu",
+        2230100 => "Shock Training",
+        2220000 => "First Intention",
+        2220100 => "Esoteric Skill Enhancement",
+        2240000 => "Energy Overflow",
+        2240100 => "Robust Spirit",
+        2340000 => "Control",
+        2340100 => "Pinnacle",
+        2470000 => "Brawl King Storm",
+        2470100 => "Asura's Path",
+        2390000 => "Esoteric Flurry",
+        2390010 => "Deathblow",
+        2300000 => "Barrage Enhancement",
+        2300100 => "Firepower Enhancement",
+        2290000 => "Enhanced Weapon",
+        2290100 => "Pistoleer",
+        2280000 => "Death Strike",
+        2280100 => "Loyal Companion",
+        2350000 => "Evolutionary Legacy",
+        2350100 => "Arthetinean Skill",
+        2380000 => "Peacemaker",
+        2380100 => "Time to Hunt",
+        2370000 => "Igniter",
+        2370100 => "Reflux",
+        2190000 => "Grace of the Empress",
+        2190100 => "Order of the Emperor",
+        2200000 => "Communication Overflow",
+        2200100 => "Master Summoner",
+        2210000 => "Desperate Salvation",
+        2210100 => "True Courage",
+        2270000 => "Demonic Impulse",
+        2270600 => "Perfect Suppression",
+        2250000 => "Surge",
+        2250600 => "Remaining Energy",
+        2260000 => "Lunar Voice",
+        2260600 => "Hunger",
+        2460000 => "Full Moon Harvester",
+        2460600 => "Night's Edge",
+        2320000 => "Wind Fury",
+        2320600 => "Drizzle",
+        2310000 => "Full Bloom",
+        2310600 => "Recurrence",
+        2330000 => "Ferality",
+        2330100 => "Phantom Beast Awakening",
+        _ => "Unknown",
+    }
+    .to_string()
+}
+
+pub fn get_class_from_id(class_id: &u32) -> String {
+    let class = match class_id {
+        0 => "",
+        101 => "Warrior (Male)",
+        102 => "Berserker",
+        103 => "Destroyer",
+        104 => "Gunlancer",
+        105 => "Paladin",
+        111 => "Female Warrior",
+        112 => "Slayer",
+        113 => "Valkyrie",
+        201 => "Mage",
+        202 => "Arcanist",
+        203 => "Summoner",
+        204 => "Bard",
+        205 => "Sorceress",
+        301 => "Martial Artist (Female)",
+        302 => "Wardancer",
+        303 => "Scrapper",
+        304 => "Soulfist",
+        305 => "Glaivier",
+        311 => "Martial Artist (Male)",
+        312 => "Striker",
+        313 => "Breaker",
+        401 => "Assassin",
+        402 => "Deathblade",
+        403 => "Shadowhunter",
+        404 => "Reaper",
+        405 => "Souleater",
+        501 => "Gunner (Male)",
+        502 => "Sharpshooter",
+        503 => "Deadeye",
+        504 => "Artillerist",
+        505 => "Machinist",
+        511 => "Gunner (Female)",
+        512 => "Gunslinger",
+        601 => "Specialist",
+        602 => "Artist",
+        603 => "Aeromancer",
+        604 => "Wildsoul",
+        _ => "Unknown",
+    };
+
+    class.to_string()
+}


### PR DESCRIPTION
Another round of infrastructure work.
The final PR will tie these pieces together and slim down `main.rs`.

- Moved all tray and window event handling into `ui`.
- Extracted setup into its own file.
- Background worker module.
- Introduced shell module as a wrapper for external interactions (e.g. launching the game, opening Explorer).
- Added additional fields to context to support database migration