### PR TITLE
[windows] fix autostart

### DIFF
--- a/src-tauri/src/app/autostart/windows.rs
+++ b/src-tauri/src/app/autostart/windows.rs
@@ -1,8 +1,10 @@
-use std::process::Command;
+use std::{os::windows::process::CommandExt, process::Command};
 use anyhow::Result;
 use log::*;
 
 use crate::constants::TASK_NAME;
+
+const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 const IS_ENABLED_SCRIPT: &'static str = r#"Get-ScheduledTask -TaskName "{name}""#;
 
@@ -38,6 +40,7 @@ impl AutoLaunchManager {
 
     fn run_powershell(script: &str) -> Result<bool> {
         let output = Command::new("powershell")
+            .creation_flags(CREATE_NO_WINDOW) 
             .args(["-NoProfile", "-NonInteractive", "-Command", script])
             .output()?;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
             setup_tray(app_handle)?;
 
             let app_path = std::env::current_exe()?.display().to_string();
-            app.manage(AutoLaunchManager::new(&app.package_info().name, &app_path));
+            app.manage(AutoLaunchManager::new(&app_path));
 
             let update_checked = Arc::new(AtomicBool::new(false));
             let checked_clone = update_checked.clone();


### PR DESCRIPTION
Replaced `schtasks.exe` with PowerShell `Register-ScheduledTask`, enabling the auto-start task to specify a working directory, which schtasks does not support.
