### PR TITLE
Switch to COM API for Task Scheduler

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,7 @@ tauri-plugin-single-instance = "2.3.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 nt_version = "0.1.3"
+winsafe = { version = "0.0.25", features = ["taskschd"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 auto-launch = "0.5.0"
@@ -84,3 +85,7 @@ debug = false # Disable debug symbols for dependencies
 [profile.dev]
 incremental = true
 opt-level = 0
+
+[patch.crates-io]
+# Patch until https://github.com/rodrigocfd/winsafe/pull/168 is merged
+winsafe = { git = "https://github.com/anyduck/winsafe.git", rev = "1a6250e" }

--- a/src-tauri/src/app/autostart/linux.rs
+++ b/src-tauri/src/app/autostart/linux.rs
@@ -1,13 +1,14 @@
 use anyhow::Result;
 use auto_launch::{AutoLaunch, AutoLaunchBuilder};
+use std::path::Path;
 
 pub struct AutoLaunchManager(AutoLaunch);
 
 impl AutoLaunchManager {
-    pub fn new(app_name: &str, app_path: &str) -> Self {
+    pub fn new(app_name: &str, app_path: &Path) -> Self {
         let auto = AutoLaunchBuilder::new()
             .set_app_name(app_name)
-            .set_app_path(app_path)
+            .set_app_path(app_path.display().to_string())
             .build()
             .unwrap();
         Self(auto)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -79,8 +79,10 @@ async fn main() -> Result<()> {
 
             setup_tray(app_handle)?;
 
-            let app_path = std::env::current_exe()?.display().to_string();
-            app.manage(AutoLaunchManager::new(&app.package_info().name, &app_path));
+            app.manage(AutoLaunchManager::new(
+                &app.package_info().name,
+                &std::env::current_exe()?,
+            ));
 
             let update_checked = Arc::new(AtomicBool::new(false));
             let checked_clone = update_checked.clone();
@@ -1570,9 +1572,13 @@ fn check_start_on_boot(auto: State<AutoLaunchManager>) -> bool {
 
 #[tauri::command]
 fn set_start_on_boot(auto: State<AutoLaunchManager>, set: bool) {
-    let _ = match set {
+    let result = match set {
         true => auto.enable(),
         false => auto.disable(),
+    };
+    match result {
+        Ok(_) => info!("set start on boot to {}", set),
+        Err(e) => error!("could not set start on boot: {}", e),
     };
 }
 


### PR DESCRIPTION
Thanks to [Sikari](https://discord.com/channels/1174544914139328572/1196224567337824406/1418614192579285136) for the solution. I guess Tauri v2 needs CWD to be set, which can't be done with `schtasks.exe`

I tried doing it with PowerShell but wasn't able to figure out multiline inputs. Idk whether COM API is too low level, but here's the patch anyway

<details>
  <summary>Created task is almost the same as before</summary>
  
  ```diff
diff --git a/task.xml b/task.xml
index 950d8656..98a386a0 100644
--- a/task.xml
+++ b/task.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
-    <Date>2025-09-19T22:47:11</Date>
-    <Author>DESKTOP-U1QQ3NC\Anyduck</Author>
     <URI>\LOA_Logs_Auto_Start</URI>
   </RegistrationInfo>
   <Principals>
@@ -24,13 +22,12 @@
     </IdleSettings>
   </Settings>
   <Triggers>
-    <LogonTrigger>
-      <StartBoundary>2025-09-19T22:47:00</StartBoundary>
-    </LogonTrigger>
+    <LogonTrigger />
   </Triggers>
   <Actions Context="Author">
     <Exec>
-      <Command>"C:\Users\Anyduck\AppData\Local\LOA Logs\LOA Logs.exe"</Command>
+      <Command>C:\Users\Anyduck\AppData\Local\LOA Logs\LOA Logs.exe</Command>
+      <WorkingDirectory>C:\Users\Anyduck\AppData\Local\LOA Logs</WorkingDirectory>
     </Exec>
   </Actions>
 </Task>
\ No newline at end of file
```
</details>

