### PR TITLE
Small fixes and nits

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5983,9 +5983,8 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d92153331e7d02ec09137538996a7786fe679c629c279e82a6be762b7e6fe2"
+version = "0.21.0"
+source = "git+https://github.com/tauri-apps/tray-icon.git?rev=tray-icon-v0.21.0#34a3442868725d53c042d619f5c60c84dc5072df"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -84,3 +84,7 @@ debug = false # Disable debug symbols for dependencies
 [profile.dev]
 incremental = true
 opt-level = 0
+
+[patch.crates-io]
+# Downgrade until https://github.com/tauri-apps/tao/issues/1140 is resolved
+tray-icon = { git = "https://github.com/tauri-apps/tray-icon.git", rev = "tray-icon-v0.21.0" }

--- a/src-tauri/nsis/hooks.nsh
+++ b/src-tauri/nsis/hooks.nsh
@@ -1,0 +1,15 @@
+!macro NSIS_HOOK_PREINSTALL
+
+!macroend
+
+!macro NSIS_HOOK_POSTINSTALL
+
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+
+!macroend
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  Delete /REBOOTOK "$INSTDIR\WinDivert64.sys"
+!macroend

--- a/src-tauri/nsis/installer.nsi
+++ b/src-tauri/nsis/installer.nsi
@@ -790,9 +790,6 @@ Section Uninstall
   ; Delete uninstaller
   Delete "$INSTDIR\uninstall.exe"
 
-  IfFileExists "$INSTDIR\WinDivert64.sys" 0 +2
-    Delete /REBOOTOK "$INSTDIR\WinDivert64.sys"
-
   {{#each resources_ancestors}}
   RMDir /REBOOTOK "$INSTDIR\\{{this}}"
   {{/each}}

--- a/src-tauri/src/app/panic.rs
+++ b/src-tauri/src/app/panic.rs
@@ -3,7 +3,7 @@ use tauri_plugin_opener::OpenerExt;
 
 use crate::app;
 
-pub fn show_dialog_on_panic(app: &tauri::AppHandle, panic_message: &str) {
+fn show_dialog_on_panic(app: &tauri::AppHandle, panic_message: &str) {
     const LOG_FILENAME: &str = "loa_logs_rCURRENT.log";
     const BUTTON_OPEN: &str = "Show Log File";
 
@@ -37,10 +37,12 @@ pub fn set_hook(app: &tauri::AppHandle) {
     std::panic::set_hook(Box::new(move |info| {
         let message = format!("{info}");
         log::error!("{}", message.replace('\n', " "));
+        #[cfg(not(debug_assertions))]
+        log::error!("{:?}", std::backtrace::Backtrace::force_capture());
         log::logger().flush();
 
         if !cfg!(debug_assertions) {
-            app::panic::show_dialog_on_panic(&app, &message);
+            show_dialog_on_panic(&app, &message);
         }
     }));
 }

--- a/src-tauri/src/app/panic.rs
+++ b/src-tauri/src/app/panic.rs
@@ -37,8 +37,6 @@ pub fn set_hook(app: &tauri::AppHandle) {
     std::panic::set_hook(Box::new(move |info| {
         let message = format!("{info}");
         log::error!("{}", message.replace('\n', " "));
-        #[cfg(not(debug_assertions))]
-        log::error!("{:?}", std::backtrace::Backtrace::force_capture());
         log::logger().flush();
 
         if !cfg!(debug_assertions) {

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -14,6 +14,7 @@
       "timestampUrl": "",
       "nsis": {
         "template": "./nsis/installer.nsi",
+        "installerHooks": "./nsis/hooks.nsh",
         "installerIcon": "icons/icon.ico",
         "minimumWebview2Version": "119.0.2151.97"
       }


### PR DESCRIPTION
 - Fix [crash](https://discord.com/channels/1174544914139328572/1196224567337824406/1418093502688137226) by downgrading `tray-icon` due to [tao#1140](https://www.github.com/tauri-apps/tao/issues/1140)
 - Extracted custom parts from `insaller.nsi` into `hooks.nsh`, so they wouldn't be overwritten after next script update
 
It would be convenient to move trickery with windivert service into nsi hooks. But it's not worth it to change from an already working system