### PR TITLE
Implement LiveManager to handle events (reset, save, pause, etc.)

### DIFF
--- a/src-tauri/src/live/manager.rs
+++ b/src-tauri/src/live/manager.rs
@@ -1,0 +1,158 @@
+use std::sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex};
+
+use log::*;
+use tauri::{AppHandle, Emitter, Event, EventId, Listener};
+
+pub struct LiveManager {
+    app_handle: AppHandle,
+    subscriptions: Mutex<Vec<EventId>>,
+    reset: AtomicBool,
+    save: AtomicBool,
+    pause: AtomicBool,
+    boss_only_damage: AtomicBool,
+    emit_details: AtomicBool,
+}
+
+impl LiveManager {
+    pub fn new(app_handle: AppHandle) -> Arc<Self> {
+
+        let reset = AtomicBool::new(false);
+        let pause = AtomicBool::new(false);
+        let save = AtomicBool::new(false);
+        let boss_only_damage = AtomicBool::new(false);
+        let emit_details = AtomicBool::new(false);
+
+        let listener = Arc::new(Self {
+            app_handle: app_handle.clone(),
+            subscriptions: Mutex::new(vec![]),
+            reset,
+            save,
+            pause,
+            boss_only_damage,
+            emit_details
+        });
+        
+        let mut subscriptions = vec![];
+        let id = app_handle.listen_any("reset-request", Self::on_reset(listener.clone()));
+        subscriptions.push(id);
+        
+        let id = app_handle.listen_any("save-request", Self::on_save(listener.clone()));
+        subscriptions.push(id);
+
+        let id = app_handle.listen_any("pause-request", Self::on_pause(listener.clone()));
+        subscriptions.push(id);
+
+        let id = app_handle.listen_any("boss-only-damage-request", Self::on_boss_only_damage(listener.clone()));
+        subscriptions.push(id);
+
+        let id = app_handle.listen_any("emit-details-request", Self::on_emit_details(listener.clone()));
+        subscriptions.push(id);
+
+        *listener.subscriptions.lock().unwrap() = subscriptions;
+
+        listener
+    }
+
+    fn on_reset(context: Arc<LiveManager>) -> impl Fn(Event) + Send + 'static {
+        
+        move |_| {
+            context.reset.store(true, Ordering::Relaxed);
+            info!("resetting meter");
+            context.app_handle.emit("reset-encounter", "").unwrap();
+        }
+    }
+
+    fn on_save(context: Arc<LiveManager>) -> impl Fn(Event) + Send + 'static {
+        move |_| {
+            context.save.store(true, Ordering::Relaxed);
+            info!("manual saving encounter");
+            context.app_handle.emit("save-encounter", "").unwrap();
+        }
+    }
+
+    fn on_pause(context: Arc<LiveManager>) -> impl Fn(Event) + Send + 'static {
+        move |_| {
+            let prev = context.pause.fetch_xor(true, Ordering::Relaxed);
+
+            if prev {
+                info!("unpausing meter");
+            } else {
+                info!("pausing meter");
+            }
+            
+            context.app_handle.emit("pause-encounter", "").unwrap();
+        }
+    }
+
+    fn on_boss_only_damage(context: Arc<LiveManager>) -> impl Fn(Event) + Send + 'static {
+        move |event: Event| {
+            let bod = event.payload();
+
+            if bod == "true" {
+                context.boss_only_damage.store(true, Ordering::Relaxed);
+                info!("boss only damage enabled")
+            } else {
+                context.boss_only_damage.store(false, Ordering::Relaxed);
+                info!("boss only damage disabled")
+            }
+        }
+    }
+
+    fn on_emit_details(context: Arc<LiveManager>) -> impl Fn(Event) + Send + 'static {
+        move |_event: Event| {
+            
+            let prev = context.emit_details.fetch_xor(true, Ordering::Relaxed);
+
+            if prev {
+                info!("stopped sending details");
+            } else {
+                info!("sending details");
+            }
+        }
+    }
+
+    pub fn set_boss_only_damage(&self) {
+        self.boss_only_damage.store(true, Ordering::Relaxed);
+    }
+
+    pub fn has_reset(&self) -> bool {
+        let value = self.reset.load(Ordering::Relaxed);
+
+        if value {
+            self.reset.store(false, Ordering::Relaxed);
+        }
+
+        value
+    }
+
+    pub fn has_paused(&self) -> bool {
+        self.pause.load(Ordering::Relaxed)
+    }
+
+    pub fn has_saved(&self) -> bool {
+        let value = self.save.load(Ordering::Relaxed);
+
+        if value {
+            self.save.store(false, Ordering::Relaxed);
+        }
+
+        value
+    }
+
+    pub fn can_emit_details(&self) -> bool {
+        self.emit_details.load(Ordering::Relaxed)
+    }
+
+    pub fn has_toggled_boss_only_damage(&self) -> bool {
+        self.boss_only_damage.load(Ordering::Relaxed)
+    }
+}
+
+
+impl Drop for LiveManager {
+    fn drop(&mut self) {
+        for subscription in self.subscriptions.lock().unwrap().drain(..) {
+            self.app_handle.unlisten(subscription);
+        }
+    }
+}

--- a/src-tauri/src/live/mod.rs
+++ b/src-tauri/src/live/mod.rs
@@ -12,7 +12,7 @@ use crate::app;
 use crate::live::encounter_state::EncounterState;
 use crate::live::entity_tracker::{EntityTracker, get_current_and_max_hp};
 use crate::live::id_tracker::IdTracker;
-use crate::live::manager::LiveManager;
+use crate::live::manager::EventManager;
 use crate::live::party_tracker::PartyTracker;
 use crate::live::stats_api::API_URL;
 use crate::live::stats_api::StatsApi;
@@ -41,7 +41,7 @@ use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
 pub fn start(app: AppHandle, port: u16, settings: Option<Settings>) -> Result<()> {
-    let manager = LiveManager::new(app.clone());
+    let manager = EventManager::new(app.clone());
     let id_tracker = Rc::new(RefCell::new(IdTracker::new()));
     let party_tracker = Rc::new(RefCell::new(PartyTracker::new(id_tracker.clone())));
     let status_tracker = Rc::new(RefCell::new(StatusTracker::new(party_tracker.clone())));


### PR DESCRIPTION
- `listen_any` and `AtomicBool` flags are moved to separate module `LiveManager`
- during app shutdown listeners are unsubscribed in `Drop` trait