### PR TITLE
fix skill dps persistence

### DIFF
--- a/src-tauri/src/database/repository.rs
+++ b/src-tauri/src/database/repository.rs
@@ -1313,8 +1313,6 @@ mod tests {
                 per_skill_map.insert(timestamp, skill_cast);
             }
 
-            skill.dps = skill.total_damage / duration_seconds;
-
             cast_log
                 .entry(entity.name.clone())
                 .or_default()

--- a/src-tauri/src/database/utils.rs
+++ b/src-tauri/src/database/utils.rs
@@ -390,6 +390,10 @@ pub fn update_entity_stats(
     entity.damage_stats.unbuffed_damage = unbuffed_damage;
     entity.damage_stats.unbuffed_dps = unbuffed_dps;
 
+    for (_, skill) in entity.skills.iter_mut() {
+        skill.dps = skill.total_damage / duration_seconds;
+    }
+
 }
 
 pub fn apply_player_info(


### PR DESCRIPTION
`update_entity_stats` missed these two lines and unit test was calculating dps as part of setup