### PR TITLE
Improve sending to UI

### DIFF
--- a/src-tauri/src/live/mod.rs
+++ b/src-tauri/src/live/mod.rs
@@ -18,7 +18,9 @@ use crate::live::status_tracker::{
     get_status_effect_value,
 };
 use crate::local::{LocalInfo, LocalPlayer, LocalPlayerRepository};
-use crate::models::{DamageData, EntityType, Identity, RdpsData, TripodIndex};
+use crate::models::*;
+use crate::models::{TripodIndex, TripodLevel};
+use crate::services::{prepare_ui_payload, UiSender};
 use crate::settings::Settings;
 use crate::utils::get_class_from_id;
 use anyhow::Result;
@@ -66,6 +68,7 @@ pub fn start(args: StartArgs) -> Result<()> {
         party_tracker.clone(),
     );
     let mut state = EncounterState::new(app.clone());
+    let mut ui_sender = UiSender::new(app.clone());
 
     let rx = match start_capture(port, region_file_path.clone()) {
         Ok(rx) => rx,
@@ -78,8 +81,6 @@ pub fn start(args: StartArgs) -> Result<()> {
     let damage_handler = meter_core::decryption::DamageEncryptionHandler::new();
     let damage_handler = damage_handler.start()?;
 
-    let mut last_update = Instant::now();
-    let mut duration = Duration::from_millis(200);
     let mut last_party_update = Instant::now();
     let party_duration = Duration::from_millis(2000);
     let mut raid_end_cd = Instant::now();
@@ -90,7 +91,7 @@ pub fn start(args: StartArgs) -> Result<()> {
             info!("boss only damage enabled")
         }
         if settings.general.low_performance_mode {
-            duration = Duration::from_millis(1500);
+            ui_sender.set_interval(Duration::from_millis(1500));
             info!("low performance mode enabled")
         }
     } else {
@@ -968,95 +969,29 @@ pub fn start(args: StartArgs) -> Result<()> {
             _ => {}
         }
 
-        if last_update.elapsed() >= duration || state.resetting || state.boss_dead_update {
+        if ui_sender.can_send() && state.resetting || state.boss_dead_update {
             let boss_dead = state.boss_dead_update;
-            if state.boss_dead_update {
-                state.boss_dead_update = false;
-            }
-            let mut clone = state.encounter.clone();
             let damage_valid = state.damage_is_valid;
-            let app_handle = app.clone();
+            try_recalculate_party(
+                &party_tracker,
+                &entity_tracker,
+                &mut party_cache,
+                &mut last_party_update,
+                party_duration,
+                party_freeze,
+            );
+            let payload = prepare_ui_payload(
+                &state.encounter,
+                party_cache.as_deref(),
+                damage_valid,
+                boss_dead
+            );
+            
+            ui_sender.try_send(payload);
+        }
 
-            let party_info: Option<Vec<Vec<String>>> =
-                if last_party_update.elapsed() >= party_duration && !party_freeze {
-                    last_party_update = Instant::now();
-
-                    // use cache if available
-                    // otherwise get party info
-                    party_cache.clone().or_else(|| {
-                        let party = update_party(&party_tracker, &entity_tracker);
-                        if party.len() > 1 {
-                            if party.iter().all(|p| p.len() == 4) {
-                                party_cache = Some(party.clone());
-                            }
-                            Some(party)
-                        } else {
-                            None
-                        }
-                    })
-                } else {
-                    None
-                };
-
-            tokio::task::spawn(async move {
-                if !clone.current_boss_name.is_empty() {
-                    let current_boss = clone.entities.get(&clone.current_boss_name).cloned();
-                    if let Some(mut current_boss) = current_boss {
-                        if boss_dead {
-                            current_boss.is_dead = true;
-                            current_boss.current_hp = 0;
-                        }
-                        clone.current_boss = Some(current_boss);
-                    } else {
-                        clone.current_boss_name = String::new();
-                    }
-                }
-                clone.entities.retain(|_, e| {
-                    ((e.entity_type == EntityType::Player && e.class_id > 0)
-                        || e.entity_type == EntityType::Esther
-                        || e.entity_type == EntityType::Boss)
-                        && e.damage_stats.damage_dealt > 0
-                });
-
-                // strip data not needed for live meter to reduce payload size and frontend memory
-                clone.encounter_damage_stats.boss_hp_log.clear();
-                for entity in clone.entities.values_mut() {
-                    entity.damage_stats.dps_average.clear();
-                    entity.damage_stats.dps_rolling_10s_avg.clear();
-                    for skill in entity.skills.values_mut() {
-                        skill.cast_log.clear();
-                        skill.skill_cast_log.clear();
-                    }
-                }
-                if let Some(ref mut boss) = clone.current_boss {
-                    boss.damage_stats.dps_average.clear();
-                    boss.damage_stats.dps_rolling_10s_avg.clear();
-                    for skill in boss.skills.values_mut() {
-                        skill.cast_log.clear();
-                        skill.skill_cast_log.clear();
-                    }
-                }
-
-                if !clone.entities.is_empty() {
-                    if !damage_valid {
-                        app_handle
-                            .emit("invalid-damage", "")
-                            .expect("failed to emit invalid-damage");
-                    } else {
-                        app_handle
-                            .emit("encounter-update", Some(clone))
-                            .expect("failed to emit encounter-update");
-
-                        if party_info.is_some() {
-                            app_handle
-                                .emit("party-update", party_info)
-                                .expect("failed to emit party-update");
-                        }
-                    }
-                }
-            });
-
-            last_update = Instant::now();
+        if state.boss_dead_update {
+            state.boss_dead_update = false;
         }
 
         if state.resetting {
@@ -1073,6 +1008,28 @@ pub fn start(args: StartArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn try_recalculate_party(
+    party_tracker: &Rc<RefCell<PartyTracker>>,
+    entity_tracker: &EntityTracker,
+    party_cache: &mut Option<Vec<Vec<String>>>,
+    last_party_update: &mut Instant,
+    party_duration: Duration,
+    party_freeze: bool,
+) {
+    if last_party_update.elapsed() >= party_duration && !party_freeze {
+        *last_party_update = Instant::now();
+
+        if party_cache.is_none() {
+            let party = update_party(&party_tracker, &entity_tracker);
+            if party.len() > 1 {
+                if party.iter().all(|p| p.len() == 4) {
+                    *party_cache = Some(party);
+                }
+            }
+        }
+    }
 }
 
 fn update_party(

--- a/src-tauri/src/live/mod.rs
+++ b/src-tauri/src/live/mod.rs
@@ -969,7 +969,7 @@ pub fn start(args: StartArgs) -> Result<()> {
             _ => {}
         }
 
-        if ui_sender.can_send() && state.resetting || state.boss_dead_update {
+        if ui_sender.can_send() || state.resetting || state.boss_dead_update {
             let boss_dead = state.boss_dead_update;
             let damage_valid = state.damage_is_valid;
             try_recalculate_party(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,6 +18,7 @@ mod setup;
 mod shell;
 mod ui;
 mod utils;
+mod services;
 
 use crate::app::autostart::AutoLaunchManager;
 use crate::constants::*;

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -5,6 +5,7 @@ pub mod misc;
 pub mod skill;
 pub mod status_effect;
 mod utils;
+mod ui;
 
 pub use data::*;
 pub use encounter::*;
@@ -12,3 +13,4 @@ pub use entity::*;
 pub use misc::*;
 pub use skill::*;
 pub use status_effect::*;
+pub use ui::*;

--- a/src-tauri/src/models/ui.rs
+++ b/src-tauri/src/models/ui.rs
@@ -1,0 +1,297 @@
+use hashbrown::{HashMap, HashSet};
+use serde::Serialize;
+
+use crate::models::*;
+
+#[derive(Debug)]
+pub enum UiPayload<'a> {
+    None,
+    InvalidDamage,
+    Data {
+        snapshot: EncounterSnapshot<'a>,
+        party_info: Option<&'a [Vec<String>]>
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncounterSnapshot<'a> {
+    pub last_combat_packet: i64,
+    pub fight_start: i64,
+    pub local_player: &'a str,
+    pub entities: HashMap<&'a String, EncounterSnapshotEntity<'a>>,
+    pub current_boss_name: &'a str,
+    pub current_boss: Option<EncounterCurrentBoss<'a>>,
+    pub encounter_damage_stats: EncounterSnapshotDamageStats<'a>,
+    pub duration: i64,
+    pub difficulty: Option<&'a str>,
+    pub boss_only_damage: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncounterSnapshotEntity<'a> {
+    pub id: u64,
+    pub character_id: u64,
+    pub npc_id: u32,
+    pub hp_bars: Option<u32>,
+    pub name: &'a str,
+    pub entity_type: EntityType,
+    pub class_id: u32,
+    pub class: &'a str,
+    pub gear_score: f32,
+    pub current_hp: i64,
+    pub max_hp: i64,
+    pub current_shield: u64,
+    pub is_dead: bool,
+    pub skills: HashMap<&'a u32, EncounterSnapshotEntitySkills<'a>>,
+    pub damage_stats: EncounterSnapshotEntityDamageStats<'a>,
+    pub skill_stats: &'a SkillStats,
+}
+
+impl<'a> From<&'a EncounterEntity> for EncounterSnapshotEntity<'a> {
+    fn from(e: &'a EncounterEntity) -> Self {
+        Self {
+            id: e.id,
+            character_id: e.character_id,
+            npc_id: e.npc_id,
+            hp_bars: e.hp_bars,
+            name: &e.name,
+            entity_type: e.entity_type,
+            class_id: e.class_id,
+            class: &e.class,
+            gear_score: e.gear_score,
+            current_hp: e.current_hp,
+            max_hp: e.max_hp,
+            current_shield: e.current_shield,
+            is_dead: e.is_dead,
+            skills: e.skills.iter()
+                .map(|(k, s)| (k, s.into()))
+                .collect(),
+            damage_stats: (&e.damage_stats).into(),
+            skill_stats: &e.skill_stats,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")] 
+pub struct EncounterSnapshotEntitySkills<'a> {
+    pub id: u32,
+    pub name: &'a str,
+    pub icon: &'a str,
+    pub total_damage: i64,
+    pub max_damage: i64,
+    pub max_damage_cast: i64,
+    pub buffed_by: &'a HashMap<u32, i64>,
+    pub debuffed_by: &'a HashMap<u32, i64>,
+    pub buffed_by_support: i64,
+    pub buffed_by_identity: i64,
+    pub buffed_by_hat: i64,
+    pub debuffed_by_support: i64,
+    pub casts: i64,
+    pub hits: i64,
+    pub crits: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adjusted_crit: Option<f64>,
+    pub crit_damage: i64,
+    pub back_attacks: i64,
+    pub front_attacks: i64,
+    pub back_attack_damage: i64,
+    pub front_attack_damage: i64,
+    pub dps: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tripod_index: Option<TripodIndex>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tripod_level: Option<TripodLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gem_cooldown: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gem_tier: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gem_damage: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gem_tier_dmg: Option<u8>,
+    #[serde(default)]
+    pub stagger: i64,
+    #[serde(default)]
+    pub is_hyper_awakening: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub special: Option<bool>,
+    #[serde(skip)]
+    pub last_timestamp: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_available: Option<i64>, // total time skill was available to cast
+    pub rdps_received: &'a HashMap<u8, HashMap<u32, i64>>,
+    pub rdps_contributed: &'a HashMap<u8, i64>,
+}
+
+impl<'a> From<&'a Skill> for EncounterSnapshotEntitySkills<'a> {
+    fn from(skill: &'a Skill) -> Self {
+        Self {
+            id: skill.id,
+            name: &skill.name,
+            icon: &skill.icon,
+            total_damage: skill.total_damage,
+            max_damage: skill.max_damage,
+            max_damage_cast: skill.max_damage_cast,
+            buffed_by: &skill.buffed_by,
+            debuffed_by: &skill.debuffed_by,
+            buffed_by_support: skill.buffed_by_support,
+            buffed_by_identity: skill.buffed_by_identity,
+            buffed_by_hat: skill.buffed_by_hat,
+            debuffed_by_support: skill.debuffed_by_support,
+            casts: skill.casts,
+            hits: skill.hits,
+            crits: skill.crits,
+            adjusted_crit: skill.adjusted_crit,
+            crit_damage: skill.crit_damage,
+            back_attacks: skill.back_attacks,
+            front_attacks: skill.front_attacks,
+            back_attack_damage: skill.back_attack_damage,
+            front_attack_damage: skill.front_attack_damage,
+            dps: skill.dps,
+            tripod_index: skill.tripod_index,
+            tripod_level: skill.tripod_level,
+            gem_cooldown: skill.gem_cooldown,
+            gem_tier: skill.gem_tier,
+            gem_damage: skill.gem_damage,
+            gem_tier_dmg: skill.gem_tier_dmg,
+            stagger: skill.stagger,
+            is_hyper_awakening: skill.is_hyper_awakening,
+            special: skill.special,
+            last_timestamp: skill.last_timestamp,
+            time_available: skill.time_available,
+            rdps_received: &skill.rdps_received,
+            rdps_contributed: &skill.rdps_contributed,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncounterSnapshotEntityDamageStats<'a> {
+    pub damage_dealt: i64,
+    pub hyper_awakening_damage: i64,
+    pub damage_taken: i64,
+    pub buffed_by: &'a HashMap<u32, i64>,
+    pub debuffed_by: &'a HashMap<u32, i64>,
+    pub buffed_by_support: i64,
+    pub buffed_by_identity: i64,
+    pub debuffed_by_support: i64,
+    pub buffed_by_hat: i64,
+    pub crit_damage: i64,
+    pub back_attack_damage: i64,
+    pub front_attack_damage: i64,
+    pub shields_given: u64,
+    pub shields_received: u64,
+    pub damage_absorbed: u64,
+    pub damage_absorbed_on_others: u64,
+    pub shields_given_by: &'a HashMap<u32, u64>,
+    pub shields_received_by: &'a HashMap<u32, u64>,
+    pub damage_absorbed_by: &'a HashMap<u32, u64>,
+    pub damage_absorbed_on_others_by: &'a HashMap<u32, u64>,
+    pub deaths: i64,
+    pub death_time: i64,
+    pub dps: i64,
+    #[serde(default)]
+    pub stagger: i64,
+    #[serde(skip)]
+    pub buffed_damage: i64,
+    #[serde(default)]
+    pub unbuffed_damage: i64,
+    #[serde(default)]
+    pub unbuffed_dps: i64,
+}
+
+impl<'a> From<&'a DamageStats> for EncounterSnapshotEntityDamageStats<'a> {
+    fn from(d: &'a DamageStats) -> Self {
+        Self {
+            damage_dealt: d.damage_dealt,
+            hyper_awakening_damage: d.hyper_awakening_damage,
+            damage_taken: d.damage_taken,
+            buffed_by: &d.buffed_by,
+            debuffed_by: &d.debuffed_by,
+            buffed_by_support: d.buffed_by_support,
+            buffed_by_identity: d.buffed_by_identity,
+            debuffed_by_support: d.debuffed_by_support,
+            buffed_by_hat: d.buffed_by_hat,
+            crit_damage: d.crit_damage,
+            back_attack_damage: d.back_attack_damage,
+            front_attack_damage: d.front_attack_damage,
+            shields_given: d.shields_given,
+            shields_received: d.shields_received,
+            damage_absorbed: d.damage_absorbed,
+            damage_absorbed_on_others: d.damage_absorbed_on_others,
+            shields_given_by: &d.shields_given_by,
+            shields_received_by: &d.shields_received_by,
+            damage_absorbed_by: &d.damage_absorbed_by,
+            damage_absorbed_on_others_by: &d.damage_absorbed_on_others_by,
+            deaths: d.deaths,
+            death_time: d.death_time,
+            dps: d.dps,
+            stagger: d.stagger,
+            buffed_damage: d.buffed_damage,
+            unbuffed_damage: d.unbuffed_damage,
+            unbuffed_dps: d.unbuffed_dps,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncounterSnapshotDamageStats<'a> {
+    pub total_damage_dealt: i64,
+    pub top_damage_dealt: i64,
+    pub total_damage_taken: i64,
+    pub top_damage_taken: i64,
+    pub dps: i64,
+    pub buffs: &'a HashMap<u32, StatusEffect>,
+    pub debuffs: &'a HashMap<u32, StatusEffect>,
+    pub total_shielding: u64,
+    pub total_effective_shielding: u64,
+    pub applied_shield_buffs: &'a HashMap<u32, StatusEffect>,
+    #[serde(skip)]
+    pub unknown_buffs: &'a HashSet<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub misc: Option<&'a EncounterMisc>,
+}
+
+impl<'a> From<&'a EncounterDamageStats> for EncounterSnapshotDamageStats<'a> {
+    fn from(stats: &'a EncounterDamageStats) -> Self {
+        Self {
+            total_damage_dealt: stats.total_damage_dealt,
+            top_damage_dealt: stats.top_damage_dealt,
+            total_damage_taken: stats.total_damage_taken,
+            top_damage_taken: stats.top_damage_taken,
+            dps: stats.dps,
+            buffs: &stats.buffs,
+            debuffs: &stats.debuffs,
+            total_shielding: stats.total_shielding,
+            total_effective_shielding: stats.total_effective_shielding,
+            applied_shield_buffs: &stats.applied_shield_buffs,
+            unknown_buffs: &stats.unknown_buffs,
+            misc: stats.misc.as_ref(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncounterCurrentBoss<'a> {
+    pub id: u64,
+    pub npc_id: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hp_bars: Option<u32>,
+    pub name: &'a str,
+    pub entity_type: EntityType,
+    pub current_hp: i64,
+    pub max_hp: i64,
+    pub current_shield: u64,
+    pub is_dead: bool,
+    pub skills: &'a HashMap<u32, Skill>,
+    pub damage_stats: &'a DamageStats,
+    pub skill_stats: &'a SkillStats,
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,0 +1,3 @@
+mod ui_sender;
+
+pub use ui_sender::*;

--- a/src-tauri/src/services/ui_sender.rs
+++ b/src-tauri/src/services/ui_sender.rs
@@ -1,0 +1,151 @@
+use std::time::{Duration, Instant};
+
+use hashbrown::HashMap;
+use tauri::{AppHandle, Emitter, EventTarget};
+
+use crate::models::*;
+
+pub struct UiSender {
+    app_handle: AppHandle,
+    updated_on: Instant,
+    throttle_interval: Duration
+}
+
+impl UiSender {
+    pub fn new(app_handle: AppHandle) -> Self {
+        Self {
+            app_handle,
+            updated_on: Instant::now(),
+            throttle_interval: Duration::from_millis(200)
+        }
+    }
+
+    pub fn can_send(&mut self) -> bool {
+        self.updated_on.elapsed() >= self.throttle_interval
+    }
+
+    pub fn set_interval(&mut self, value: Duration) {
+        self.throttle_interval = value;
+    }
+
+    pub fn try_send(&mut self, payload: UiPayload) {
+        // It's safe to use unwrap_unchecked
+        // - we do not send events with name descriptor containing : - , / or _
+        // - json is generated statically from rust structs
+        unsafe {
+            match payload {
+                UiPayload::None => {},
+                UiPayload::InvalidDamage => {
+                    self.app_handle.emit_str_filter("invalid-damage", String::default(), Self::main_or_mini).unwrap_unchecked();
+                },
+                UiPayload::Data { snapshot, party_info } => {
+                    let json = serde_json::to_string(&snapshot).unwrap_unchecked();
+                    self.app_handle.emit_str_filter("encounter-update", json, Self::main_or_mini).unwrap_unchecked();
+
+                    if let Some(party_info) = party_info {
+                        let json = serde_json::to_string(&party_info).unwrap_unchecked();
+                        self.app_handle.emit_str_filter("party-update", json, Self::main_or_mini).unwrap_unchecked();
+                    }
+                },
+            }
+
+            self.updated_on = Instant::now();
+        }
+    }
+
+    fn main_or_mini(target: &EventTarget) -> bool {
+        match target {
+            EventTarget::Window { label } 
+                | EventTarget::Webview { label } 
+                | EventTarget::WebviewWindow { label }=> matches!(label.as_str(), "main" | "mini"),
+            _ => false,
+        }
+    }
+}
+
+pub fn prepare_ui_payload<'a>(
+    encounter: &'a Encounter,
+    party_info: Option<&'a [Vec<String>]>,
+    damage_valid: bool,
+    boss_dead: bool
+) -> UiPayload<'a> {
+        
+    if !damage_valid {
+        return UiPayload::InvalidDamage;
+    }
+
+    let entities: HashMap<_, _> = encounter.entities.iter()
+        .filter(is_entity_valid_for_ui)
+        .map(|(k, e)| (k, e.into()))
+        .collect();
+
+    if entities.is_empty() {
+        return UiPayload::None;
+    }
+
+    let mut snapshot = EncounterSnapshot {
+        last_combat_packet: encounter.last_combat_packet,
+        fight_start: encounter.fight_start,
+        local_player: &encounter.local_player,
+        entities,
+        current_boss_name: "",
+        current_boss: None,
+        encounter_damage_stats: (&encounter.encounter_damage_stats).into(),
+        duration: encounter.duration,
+        difficulty: encounter.difficulty.as_deref(),
+        boss_only_damage: encounter.boss_only_damage,
+        region: encounter.region.as_deref(),
+    };
+
+    snapshot.current_boss = build_current_boss(encounter, boss_dead);
+
+    if snapshot.current_boss.is_some() {
+        snapshot.current_boss_name = &encounter.current_boss_name;
+    }
+
+    UiPayload::Data { snapshot, party_info }
+}
+
+fn is_entity_valid_for_ui(item: &(&String, &EncounterEntity)) -> bool {
+    let e = item.1;
+    ((e.entity_type == EntityType::Player && e.class_id > 0)
+        || e.entity_type == EntityType::Esther
+        || e.entity_type == EntityType::Boss)
+        && e.damage_stats.damage_dealt > 0
+}
+
+fn build_current_boss<'a>(
+    encounter: &'a Encounter,
+    boss_dead: bool,
+) -> Option<EncounterCurrentBoss<'a>> {
+
+    let name = &encounter.current_boss_name;
+    let boss = encounter.entities.get(name)?;
+
+    if name.is_empty() {
+        return None;
+    }
+
+    let mut current_hp = boss.current_hp;
+    let mut is_dead = boss.is_dead;
+
+    if boss_dead {
+        current_hp = 0;
+        is_dead = true;
+    }
+
+    Some(EncounterCurrentBoss {
+        id: boss.id,
+        npc_id: boss.npc_id,
+        hp_bars: boss.hp_bars,
+        name,
+        entity_type: boss.entity_type,
+        current_hp,
+        max_hp: boss.max_hp,
+        current_shield: boss.current_shield,
+        is_dead,
+        skills: &boss.skills,
+        damage_stats: &boss.damage_stats,
+        skill_stats: &boss.skill_stats,
+    })
+}


### PR DESCRIPTION
I noticed there was an [an attempt](https://github.com/snoww/loa-logs/commit/2efecbb3d1bf2e11dcb9b4f7f3af888737ffb2b3#diff-1377f5de036d6f89f916a33c27a4ecce74dab6ac1a121aa9d5cf4ca1864b6eaa)  to improve the logic, but the underlying issue still persists.

The processor pipeline still clones the entire `Encounter`. If the raid is already in an advanced state, this can cause a noticeable memory spike on each update, since everything contained within `Encounter` is cloned as well.

The snapshot structs `EncounterSnapshot*` introduce a proper boundary where the UI receives a borrowed view of the encounter data instead of a mutated clone. This reduces allocations and separates the `EncounterState` from the UI serialization layer.

Unfortunately my testing capabilities are limited (I can only construct an `EncounterState` with example data), so any live testing would be appreciated.

Tested with this mini suite
<img width="562" height="358" alt="image" src="https://github.com/user-attachments/assets/29ccb744-7562-4b66-b2a0-b7be52ecc2ff" />
```rust
#[derive(Debug)]
pub struct FakePacketCapture;
impl meter_core::PacketCapture for FakePacketCapture {
    fn start(
        &self,
        port: u16,
        region_file_path: String,
    ) -> Result<std::sync::mpsc::Receiver<(Pkt, Vec<u8>)>> {
        let (tx, rx) = std::sync::mpsc::channel();

        thread::spawn(move || {
            loop {
                tx.send((Pkt::SkillDamageNotify, vec![])).unwrap();
                std::thread::sleep(Duration::from_millis(500));
            }
        });

        Ok(rx)
    }
}

meter_core::set_packet_capture_impl(FakePacketCapture);

let mut state = EncounterState::new(app.clone());
{
        let entity = entity_tracker.init_pc(PKTInitPC {
            player_id: 1,
            name: "Local".into(),
            character_id: 1,
            class_id: 702,
            gear_level: 1755.0,
            stat_pairs: vec![],
            status_effect_datas: vec![],
        });
        state.on_init_pc(entity, 400_000, 400_000);
        let entity = state.encounter.entities.get_mut("Local").unwrap();
        entity.damage_stats.damage_dealt = 100_000_000;
        entity.skills.insert(1, Skill { total_damage: 100_000_000, ..Default::default()});

        entity_tracker.party_info(PKTPartyInfo {
            party_instance_id: 1,
            raid_instance_id: 1,
            party_member_datas: vec![
                PKTPartyInfoInner { name: "Local".into(), class_id: 702, character_id: 1, gear_level: 1755.0 },
                PKTPartyInfoInner { name: "Playera".into(), class_id: 102, character_id: 2, gear_level: 1755.0 },
                PKTPartyInfoInner { name: "Playerb".into(), class_id: 105, character_id: 3, gear_level: 1755.0 },
                PKTPartyInfoInner { name: "Playerc".into(), class_id: 604, character_id: 4, gear_level: 1755.0 }
            ],
        }, &local_info);

        let entity = entity_tracker.new_pc(PCStruct {
            player_id: 2,
            name: "Playera".into(),
            character_id: 2,
            class_id: 102,
            gear_level: 1755.0,
            stat_pairs: vec![],
            max_item_level: 1755.0,
            status_effect_datas: vec![],
        });
        state.on_new_pc(entity, 400_000, 400_000);
        let entity = state.encounter.entities.get_mut("Playera").unwrap();
        entity.damage_stats.damage_dealt = 50_000_000_000;
        entity.skills.insert(1, Skill { total_damage: 50_000_000_000, ..Default::default()});

        let entity = entity_tracker.new_pc(PCStruct {
            player_id: 3,
            name: "Playerb".into(),
            character_id: 3,
            class_id: 105,
            gear_level: 1755.0,
            stat_pairs: vec![],
            max_item_level: 1755.0,
            status_effect_datas: vec![],
        });
        state.on_new_pc(entity, 400_000, 400_000);
        let entity = state.encounter.entities.get_mut("Playerb").unwrap();
        entity.damage_stats.damage_dealt = 100_000_000;
        entity.skills.insert(1, Skill { total_damage: 100_000_000, ..Default::default()});

        let entity = entity_tracker.new_pc(PCStruct {
            player_id: 4,
            name: "Playerc".into(),
            character_id: 4,
            class_id: 604,
            gear_level: 1755.0,
            stat_pairs: vec![],
            max_item_level: 1755.0,
            status_effect_datas: vec![],
        });
        state.on_new_pc(entity, 400_000, 400_000);
        let entity = state.encounter.entities.get_mut("Playerc").unwrap();
        entity.damage_stats.damage_dealt = 100_000_000;
        entity.skills.insert(1, Skill { total_damage: 100_000_000, ..Default::default()});

        let entity = entity_tracker.new_npc(PKTNewNpc {
            npc_struct: NpcStruct {
                object_id: 3,
                type_id: 486301,
                level: 60,
                balance_level: NpcStructBalance {
                    value: Some(60),
                },
                stat_pairs: vec![],
                status_effect_datas: vec![],
            },
        }, 100_000_000_000);
        state.on_new_npc(entity, 100_000_000_000, 100_000_000_000);
        
        state.encounter.encounter_damage_stats.top_damage_dealt = 50_300_000_000;
        state.encounter.encounter_damage_stats.total_damage_dealt = 50_300_000_000;
        state.encounter.encounter_damage_stats.total_damage_taken = 100_000_000_000 - 50_300_000_000;

        let entity = state.encounter.entities.get_mut("Death Incarnate Kazeros").unwrap();
        entity.damage_stats.damage_taken = 50_300_000_000;
        entity.current_hp = 100_000_000_000 - 50_300_000_000;
    }

```