### PR TITLE
Add encounter level timeslice/zoom slider to filter all encounter/player displays.

### DIFF
--- a/src/lib/buffs.svelte.ts
+++ b/src/lib/buffs.svelte.ts
@@ -26,7 +26,10 @@ export class BuffState {
     return this.enc.players.filter((player) => player.entityType === EntityType.PLAYER);
   });
   percentages = $derived(
-    this.players.map((player) => (player.damageStats.damageDealt / this.enc.topDamageDealt) * 100)
+    this.players.map((player) => {
+      const dmg = this.enc.windowedStats?.get(player.name)?.damageDealt ?? player.damageStats.damageDealt;
+      return (dmg / this.enc.topDamageDealt) * 100;
+    })
   );
 
   groupedSynergies: Map<string, Map<number, StatusEffect>> = $derived.by(() => {
@@ -83,13 +86,19 @@ export class BuffState {
         temp.get(partyId.toString())!.set(player.name, []);
         const playerBuffs = temp.get(partyId.toString())!.get(player.name)!;
 
-        const damageDealtWithoutSpecial =
-          player.damageStats.damageDealt -
-          Object.values(player.skills)
-            .filter((skill) => skill.special)
-            .reduce((acc, skill) => acc + skill.totalDamage, 0);
-        const damageDealtWithoutSpecialAndHa =
-          damageDealtWithoutSpecial - (player.damageStats.hyperAwakeningDamage ?? 0);
+        const ws = this.enc.windowedStats?.get(player.name);
+        const pBuffedBy = ws?.buffedBy ?? player.damageStats.buffedBy;
+        const pDebuffedBy = ws?.debuffedBy ?? player.damageStats.debuffedBy;
+        const pDamageDealt = ws?.damageDealt ?? player.damageStats.damageDealt;
+        const pSpecialDmg = ws
+          ? ws.specialDamage
+          : Object.values(player.skills)
+              .filter((skill) => skill.special)
+              .reduce((acc, skill) => acc + skill.totalDamage, 0);
+        const pHaDmg = ws?.hyperAwakeningDamage ?? (player.damageStats.hyperAwakeningDamage ?? 0);
+
+        const damageDealtWithoutSpecial = pDamageDealt - pSpecialDmg;
+        const damageDealtWithoutSpecialAndHa = damageDealtWithoutSpecial - pHaDmg;
 
         this.partyGroupedSynergies.get(partyId.toString())?.forEach((key) => {
           const buffDetails = new BuffDetails();
@@ -103,11 +112,11 @@ export class BuffState {
               isHat = true;
             }
 
-            if (player.damageStats.buffedBy[id] && syn.category === "buff") {
+            if (pBuffedBy[id] && syn.category === "buff") {
               const b = new Buff(
                 syn.source.icon,
                 customRound(
-                  (player.damageStats.buffedBy[id] /
+                  (pBuffedBy[id] /
                     (isHat ? damageDealtWithoutSpecial : damageDealtWithoutSpecialAndHa)) *
                     100
                 ),
@@ -115,21 +124,21 @@ export class BuffState {
               );
               addBardBubbles(key, b, syn);
               buffDetails.buffs.push(b);
-              buffDamage += player.damageStats.buffedBy[id];
+              buffDamage += pBuffedBy[id];
             }
-            if (player.damageStats.debuffedBy[id] && syn.category === "debuff") {
+            if (pDebuffedBy[id] && syn.category === "debuff") {
               buffDetails.buffs.push(
                 new Buff(
                   syn.source.icon,
                   customRound(
-                    (player.damageStats.debuffedBy[id] /
+                    (pDebuffedBy[id] /
                       (isHat ? damageDealtWithoutSpecial : damageDealtWithoutSpecialAndHa)) *
                       100
                   ),
                   syn.source.skill?.icon
                 )
               );
-              buffDamage += player.damageStats.debuffedBy[id];
+              buffDamage += pDebuffedBy[id];
             }
           });
           if (buffDamage > 0) {

--- a/src/lib/charts.ts
+++ b/src/lib/charts.ts
@@ -101,7 +101,8 @@ export const defaultOptions: EChartsOptions = {
       },
       moveHandleStyle: {
         color: "rgba(136,136,136)"
-      }
+      },
+      moveHandleSize: 0
     }
   ]
 };

--- a/src/lib/components/BuffSkillBreakdownRow.svelte
+++ b/src/lib/components/BuffSkillBreakdownRow.svelte
@@ -20,7 +20,7 @@
 
   let { skill, entityState, groupedSynergies, width, index }: Props = $props();
 
-  let synergyPercentageDetails: Array<BuffDetails> = $derived(getSynergyPercentageDetails(groupedSynergies, skill));
+  let synergyPercentageDetails: Array<BuffDetails> = $derived(getSynergyPercentageDetails(groupedSynergies, skill, entityState));
   let isHyperAwakening = skill.isHyperAwakening || hyperAwakeningIds.has(skill.id);
 
   const tweenedValue = new Tween(entityState.encounter.live ? 0 : width, {

--- a/src/lib/components/DamageMeterColumns.svelte
+++ b/src/lib/components/DamageMeterColumns.svelte
@@ -273,8 +273,8 @@
 {/snippet}
 
 {#snippet deaths(state: EntityState)}
-  {#if state.entity.damageStats.deaths > 0}
-    {state.entity.damageStats.deaths}
+  {#if state.deaths > 0}
+    {state.deaths}
   {:else}
     -
   {/if}
@@ -346,25 +346,25 @@
 
 {#snippet buffPct(state: EntityState)}
   {@render percentValue(
-    customRound((state.entity.damageStats.buffedBySupport / state.damageDealtWithoutSpecialOrHa) * 100)
+    customRound((state.buffedBySupport / state.damageDealtWithoutSpecialOrHa) * 100)
   )}
 {/snippet}
 
 {#snippet brandPct(state: EntityState)}
   {@render percentValue(
-    customRound((state.entity.damageStats.debuffedBySupport / state.damageDealtWithoutSpecialOrHa) * 100)
+    customRound((state.debuffedBySupport / state.damageDealtWithoutSpecialOrHa) * 100)
   )}
 {/snippet}
 
 {#snippet identityPct(state: EntityState)}
   {@render percentValue(
-    customRound((state.entity.damageStats.buffedByIdentity / state.damageDealtWithoutSpecialOrHa) * 100)
+    customRound((state.buffedByIdentity / state.damageDealtWithoutSpecialOrHa) * 100)
   )}
 {/snippet}
 
 {#snippet hatPct(state: EntityState)}
   {@render percentValue(
-    customRound(((state.entity.damageStats.buffedByHat ?? 0) / state.damageDealtWithoutSpecial) * 100)
+    customRound((state.buffedByHat / state.damageDealtWithoutSpecial) * 100)
   )}
 {/snippet}
 
@@ -377,15 +377,15 @@
 {/snippet}
 
 {#snippet stagger(state: EntityState)}
-  {#if state.entity.damageStats.stagger > 0}
-    {@render damageValue(abbreviateNumberSplit(state.entity.damageStats.stagger))}
+  {#if state.stagger > 0}
+    {@render damageValue(abbreviateNumberSplit(state.stagger))}
   {:else}
     -
   {/if}
 {/snippet}
 
 {#snippet staggerTooltip(state: EntityState)}
-  {state.entity.damageStats.stagger ? state.entity.damageStats.stagger.toLocaleString() : "N/A"}
+  {state.stagger ? state.stagger.toLocaleString() : "N/A"}
 {/snippet}
 
 {#snippet unbuffedDamage(state: EntityState)}
@@ -394,7 +394,7 @@
   {:else if !state.anyUnbuffedDamage}
     -
   {:else}
-    {@render damageValue(abbreviateNumberSplit(state.entity.damageStats.unbuffedDamage))}
+    {@render damageValue(abbreviateNumberSplit(state.unbuffedDamage))}
   {/if}
 {/snippet}
 
@@ -406,7 +406,7 @@
   {:else if !state.anyUnbuffedDamage}
     N/A
   {:else}
-    {@const unbuffed = state.entity.damageStats.unbuffedDamage}
+    {@const unbuffed = state.unbuffedDamage}
     {@const buffed = state.damageDealt - unbuffed}
     <div class="-mx-px flex flex-col space-y-1 py-px text-xs font-normal">
       <span class="text-gray-300">Base: {abbreviateNumber(unbuffed, 2)}</span>
@@ -449,7 +449,7 @@
   {#if state.hasRdpsContributions}
     {@render percentValue(customRound(state.supportContribPercent))}
   {:else if state.anyUnbuffedDamage}
-    {@const buffed = state.damageDealt - state.entity.damageStats.unbuffedDamage}
+    {@const buffed = state.damageDealt - state.unbuffedDamage}
     {@render percentValue(customRound((buffed / state.damageDealt) * 100))}
   {:else}
     -
@@ -460,7 +460,7 @@
   {#if state.hasRdpsContributions}
     The support contributed {customRound(state.supportContribPercent)}% damage to the party
   {:else if state.anyUnbuffedDamage}
-    {@const buffed = state.damageDealt - state.entity.damageStats.unbuffedDamage}
+    {@const buffed = state.damageDealt - state.unbuffedDamage}
     The support contributed {customRound((buffed / state.damageDealt) * 100)}% of the damage
   {/if}
 {/snippet}

--- a/src/lib/components/PlayerBreakdownColumns.svelte
+++ b/src/lib/components/PlayerBreakdownColumns.svelte
@@ -371,7 +371,7 @@
 {/snippet}
 
 {#snippet damageTooltip(state: SkillState)}
-  {state.skill.totalDamage.toLocaleString()}
+  {state.totalDamage.toLocaleString()}
 {/snippet}
 
 {#snippet dps(state: SkillState)}
@@ -383,7 +383,7 @@
 {/snippet}
 
 {#snippet damagePct(state: SkillState)}
-  {@render percentValue(customRound((state.skill.totalDamage / state.entity.damageDealt) * 100))}
+  {@render percentValue(customRound((state.totalDamage / state.entity.damageDealt) * 100))}
 {/snippet}
 
 {#snippet critPct(state: SkillState)}
@@ -459,8 +459,8 @@
 {#snippet buffPct(state: SkillState)}
   {#if state.skill.special || state.skill.isHyperAwakening || hyperAwakeningIds.has(state.skill.id)}
     -
-  {:else if state.skill.totalDamage > 0}
-    {@render percentValue(customRound((state.skill.buffedBySupport / state.skill.totalDamage) * 100))}
+  {:else if state.totalDamage > 0}
+    {@render percentValue(customRound((state.skill.buffedBySupport / state.totalDamage) * 100))}
   {:else}
     {@render percentValue(0)}
   {/if}
@@ -469,8 +469,8 @@
 {#snippet brandPct(state: SkillState)}
   {#if state.skill.special || state.skill.isHyperAwakening || hyperAwakeningIds.has(state.skill.id)}
     -
-  {:else if state.skill.totalDamage > 0}
-    {@render percentValue(customRound((state.skill.debuffedBySupport / state.skill.totalDamage) * 100))}
+  {:else if state.totalDamage > 0}
+    {@render percentValue(customRound((state.skill.debuffedBySupport / state.totalDamage) * 100))}
   {:else}
     {@render percentValue(0)}
   {/if}
@@ -479,8 +479,8 @@
 {#snippet idenPct(state: SkillState)}
   {#if state.skill.special || state.skill.isHyperAwakening || hyperAwakeningIds.has(state.skill.id)}
     -
-  {:else if state.skill.totalDamage > 0}
-    {@render percentValue(customRound((state.skill.buffedByIdentity / state.skill.totalDamage) * 100))}
+  {:else if state.totalDamage > 0}
+    {@render percentValue(customRound((state.skill.buffedByIdentity / state.totalDamage) * 100))}
   {:else}
     {@render percentValue(0)}
   {/if}
@@ -489,20 +489,20 @@
 {#snippet tSkillPct(state: SkillState)}
   {#if state.skill.special}
     -
-  {:else if state.skill.totalDamage > 0}
-    {@render percentValue(customRound(((state.skill.buffedByHat ?? 0) / state.skill.totalDamage) * 100))}
+  {:else if state.totalDamage > 0}
+    {@render percentValue(customRound(((state.skill.buffedByHat ?? 0) / state.totalDamage) * 100))}
   {:else}
     {@render percentValue(0)}
   {/if}
 {/snippet}
 
 {#snippet avgPerHit(state: SkillState)}
-  {@const averagePerHit = state.skill.hits > 0 ? state.skill.totalDamage / state.skill.hits : 0}
+  {@const averagePerHit = state.hits > 0 ? state.totalDamage / state.hits : 0}
   {@render damageValue(abbreviateNumberSplit(averagePerHit))}
 {/snippet}
 
 {#snippet avgPerHitTooltip(state: SkillState)}
-  {@const averagePerHit = state.skill.hits > 0 ? state.skill.totalDamage / state.skill.hits : 0}
+  {@const averagePerHit = state.hits > 0 ? state.totalDamage / state.hits : 0}
   {Math.round(averagePerHit).toLocaleString()}
 {/snippet}
 
@@ -515,11 +515,11 @@
 {/snippet}
 
 {#snippet maxHit(state: SkillState)}
-  {@render damageValue(abbreviateNumberSplit(state.skill.maxDamage))}
+  {@render damageValue(abbreviateNumberSplit(state.maxDmg))}
 {/snippet}
 
 {#snippet maxHitTooltip(state: SkillState)}
-  {state.skill.maxDamage.toLocaleString()}
+  {state.maxDmg.toLocaleString()}
 {/snippet}
 
 {#snippet maxCast(state: SkillState)}
@@ -535,20 +535,22 @@
 {/snippet}
 
 {#snippet casts(state: SkillState)}
-  {state.skill.casts}
+  {state.casts}
 {/snippet}
 
 {#snippet castsPerMinute(state: SkillState)}
-  {customRound(state.skill.casts / (state.entity.encounter.duration / 1000 / 60))}
+  {@const dur = state.wss ? state.entity.wDurMs : state.entity.encounter.duration}
+  {customRound(state.casts / (dur / 1000 / 60))}
 {/snippet}
 
 {#snippet hits(state: SkillState)}
-  {state.skill.hits}
+  {state.hits}
 {/snippet}
 
 {#snippet hitsPerMinute(state: SkillState)}
-  {#if state.skill.hits > 0}
-    {customRound(state.skill.hits / (state.entity.encounter.duration / 1000 / 60))}
+  {#if state.hits > 0}
+    {@const dur = state.wss ? state.entity.wDurMs : state.entity.encounter.duration}
+    {customRound(state.hits / (dur / 1000 / 60))}
   {:else}
     0
   {/if}
@@ -571,15 +573,17 @@
 {/snippet}
 
 {#snippet stagger(state: SkillState)}
-  {#if state.skill.stagger > 0}
-    {@render damageValue(abbreviateNumberSplit(state.skill.stagger))}
+  {@const stag = state.wss?.stagger ?? state.skill.stagger}
+  {#if stag > 0}
+    {@render damageValue(abbreviateNumberSplit(stag))}
   {:else}
     -
   {/if}
 {/snippet}
 
 {#snippet staggerTooltip(state: SkillState)}
-  {state.skill.stagger ? state.skill.stagger.toLocaleString() : "N/A"}
+  {@const stag = state.wss?.stagger ?? state.skill.stagger}
+  {stag ? stag.toLocaleString() : "N/A"}
 {/snippet}
 
 {#snippet unbuffedDamage(state: SkillState)}
@@ -595,7 +599,7 @@
     N/A
   {:else}
     {@const unbuffed = state.skillUnbuffedDamage}
-    {@const buffed = state.skill.totalDamage - unbuffed}
+    {@const buffed = state.totalDamage - unbuffed}
     <div class="-mx-px flex flex-col space-y-1 py-px text-xs font-normal">
       <span class="text-gray-300">Base: {abbreviateNumber(unbuffed, 2)}</span>
       <span class="text-gray-300">Buffed: {abbreviateNumber(buffed, 2)}</span>

--- a/src/lib/components/TimeWindowSlider.svelte
+++ b/src/lib/components/TimeWindowSlider.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { chartable } from "$lib/charts";
+  import { screenshot } from "$lib/stores.svelte";
+  import { onDestroy } from "svelte";
+  import type { EChartsOptions } from "$lib/charts";
+
+  let {
+    durationSec,
+    dpsData,
+    bossHpData,
+    oncommit,
+    class: className = ""
+  }: {
+    durationSec: number;
+    dpsData: number[];
+    bossHpData: { bars: number; p: number }[];
+    oncommit: (w: { startSec: number; endSec: number } | null) => void;
+    class?: string;
+  } = $props();
+
+  let containerEl: HTMLElement | null = $state(null);
+  let destroyChart: (() => void) | null = null;
+  let chartUpdate: ((opts: EChartsOptions) => void) | null = null;
+  let echartsInst: any = null;
+  let isActive = $state(false);
+  let commitTimer: ReturnType<typeof setTimeout> | null = null;
+  let initialized = false;
+
+  function formatTime(sec: number): string {
+    const m = Math.floor(sec / 60);
+    const s = Math.floor(sec % 60);
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  }
+
+  function labelFormatter(_: string, valueStr: string): string {
+    const sec = Number(valueStr);
+    if (isNaN(sec)) return "";
+    const time = formatTime(sec);
+    const idx = Math.round(sec / 5);
+    if (bossHpData.length > 0 && idx < bossHpData.length) {
+      const entry = bossHpData[idx];
+      const pct = (entry.p * 100).toFixed(1);
+      return entry.bars > 0 ? `${time}  ${entry.bars}x ${pct}%` : `${time}  ${pct}%`;
+    }
+    return time;
+  }
+
+  function buildOptions(): EChartsOptions {
+    return {
+      grid: { left: 0, right: 0, top: 0, bottom: 0, height: 0 },
+      xAxis: {
+        type: "category",
+        show: false,
+        data: dpsData.map((_, i) => i * 5)
+      },
+      yAxis: { type: "value", show: false },
+      series: [
+        {
+          type: "line",
+          data: dpsData,
+          showSymbol: false,
+          smooth: 0.1,
+          lineStyle: { width: 0 },
+          areaStyle: { opacity: 0 },
+          silent: true
+        }
+      ],
+      dataZoom: [
+        {
+          type: "slider",
+          xAxisIndex: 0,
+          fillerColor: "rgba(80,80,80,.5)",
+          borderColor: "rgba(80,80,80,.5)",
+          handleStyle: { color: "rgba(80,80,80,.5)" },
+          moveHandleStyle: { color: "rgba(136,136,136)" },
+          moveHandleSize: 0,
+          height: 24,
+          bottom: 4,
+          left: 50,
+          right: 50,
+          showDetail: true,
+          labelFormatter: labelFormatter,
+          textStyle: {
+            color: "#e5e5e5",
+            fontSize: 11
+          }
+        }
+      ],
+      tooltip: { show: false }
+    };
+  }
+
+  // Create chart once when container mounts
+  $effect(() => {
+    if (containerEl && !initialized) {
+      initialized = true;
+      const opts = buildOptions();
+      const { destroy, echartsInstance, update } = chartable(containerEl, opts);
+      destroyChart = destroy;
+      chartUpdate = update;
+      echartsInst = echartsInstance;
+
+      echartsInstance.on("datazoom", (params: any) => {
+        const start = params.start ?? params.batch?.[0]?.start ?? 0;
+        const end = params.end ?? params.batch?.[0]?.end ?? 100;
+        isActive = !(start <= 0.01 && end >= 99.99);
+        if (commitTimer) clearTimeout(commitTimer);
+        commitTimer = setTimeout(() => {
+          const startSec = Math.round((start / 100) * durationSec);
+          const endSec = Math.round((end / 100) * durationSec);
+          oncommit(isActive ? { startSec, endSec } : null);
+        }, 150);
+      });
+    }
+  });
+
+  // Update chart data without recreating
+  $effect(() => {
+    if (chartUpdate && dpsData.length > 0) {
+      chartUpdate(buildOptions());
+    }
+  });
+
+  onDestroy(() => {
+    if (commitTimer) clearTimeout(commitTimer);
+    if (destroyChart) destroyChart();
+  });
+
+  function reset() {
+    echartsInst?.dispatchAction({ type: "dataZoom", start: 0, end: 100 });
+    isActive = false;
+    oncommit(null);
+  }
+
+</script>
+
+{#if !screenshot.state}
+  <div class="flex items-center gap-1 {className}">
+    <div class="min-w-0 flex-1 h-[40px]" bind:this={containerEl}></div>
+    <button
+      onclick={reset}
+      class="w-5 shrink-0 text-center text-xs text-neutral-500 transition hover:text-white {isActive
+        ? ''
+        : 'invisible'}"
+      title="Reset window"
+    >
+      ✕
+    </button>
+  </div>
+{/if}

--- a/src/lib/encounter.svelte.ts
+++ b/src/lib/encounter.svelte.ts
@@ -2,6 +2,7 @@ import { type Encounter, type Entity, EntityType } from "$lib/types";
 import { sumRdpsContributed } from "./skill.svelte";
 import { settings } from "./stores.svelte";
 import { timestampToMinutesAndSeconds } from "./utils";
+import { computeWindowedEntityStats, type WindowedEntityStats } from "./utils/windowedStats";
 
 export class EncounterState {
   live = false;
@@ -9,6 +10,30 @@ export class EncounterState {
   encounter: Encounter | undefined = $state();
   curSettings = $derived(this.live ? settings.app.meter : settings.app.logs);
   end = $derived(this.encounter?.lastCombatPacket ?? 0);
+
+  timeWindow: { startMs: number; endMs: number } | null = $state(null);
+
+  windowDurationMs = $derived(
+    this.timeWindow ? this.timeWindow.endMs - this.timeWindow.startMs : (this.encounter?.duration ?? 0)
+  );
+
+  windowedStats = $derived.by((): Map<string, WindowedEntityStats> | null => {
+    if (!this.timeWindow || !this.encounter) return null;
+    const map = new Map<string, WindowedEntityStats>();
+    for (const player of this.players) {
+      map.set(
+        player.name,
+        computeWindowedEntityStats(
+          player,
+          this.encounter,
+          this.timeWindow.startMs,
+          this.timeWindow.endMs,
+          this.timeWindow.endMs - this.timeWindow.startMs
+        )
+      );
+    }
+    return map;
+  });
 
   duration = $state(this.encounter?.duration ?? 0);
   region = $derived.by(() => {
@@ -93,7 +118,16 @@ export class EncounterState {
     )
   );
 
-  topDamageDealt = $derived(this.encounter?.encounterDamageStats.topDamageDealt ?? 0);
+  topDamageDealt = $derived.by(() => {
+    if (this.windowedStats) {
+      let max = 0;
+      for (const ws of this.windowedStats.values()) {
+        if (ws.damageDealt > max) max = ws.damageDealt;
+      }
+      return max;
+    }
+    return this.encounter?.encounterDamageStats.topDamageDealt ?? 0;
+  });
 
   /**
    * Array of damage dealt percentages for each player in the encounter, relative to the highest damage dealt.
@@ -102,13 +136,21 @@ export class EncounterState {
    */
   playerDamagePercentages = $derived.by(() => {
     if (this.topDamageDealt === 0) return [];
-    return this.players.map((player) => (player.damageStats.damageDealt / this.topDamageDealt) * 100);
+    return this.players.map((player) => {
+      const dmg = this.windowedStats?.get(player.name)?.damageDealt ?? player.damageStats.damageDealt;
+      return (dmg / this.topDamageDealt) * 100;
+    });
   });
 
   /**
    * Sum of all damage dealt by players in the encounter, including esthers if showEsther is enabled.
    */
   totalDamageDealt = $derived.by(() => {
+    if (this.windowedStats) {
+      let total = 0;
+      for (const ws of this.windowedStats.values()) total += ws.damageDealt;
+      return total;
+    }
     if (settings.app.general.showEsther) {
       // include esthers in the total damage dealt
       return (
@@ -186,7 +228,12 @@ export class EncounterState {
    * Indexes in the array, and sub array correspond to the indexes in `this.parties`
    */
   partyDamagePercentages = $derived(
-    this.parties.map((party) => party.map((player) => (player.damageStats.damageDealt / this.topDamageDealt) * 100))
+    this.parties.map((party) =>
+      party.map((player) => {
+        const dmg = this.windowedStats?.get(player.name)?.damageDealt ?? player.damageStats.damageDealt;
+        return (dmg / this.topDamageDealt) * 100;
+      })
+    )
   );
 
   /**

--- a/src/lib/entity.svelte.ts
+++ b/src/lib/entity.svelte.ts
@@ -161,7 +161,7 @@ export class EntityState {
   skills = $derived.by(() => {
     if (!this.entity) return [];
     const sd = this.ws?.skillDamage;
-    const dmg = (s: { id: number; totalDamage: number }) => sd?.get(s.id) ?? s.totalDamage;
+    const dmg = (s: { id: number; totalDamage: number }) => sd ? (sd.get(s.id) ?? 0) : s.totalDamage;
     let arr = Object.values(this.entity.skills);
     if (this.entity.class === "Arcanist") {
       arr = arr.filter((skill) => !cardIds.includes(skill.id));
@@ -172,14 +172,14 @@ export class EntityState {
   mostDamageSkill = $derived.by(() => {
     if (this.skills.length === 0) return 0;
     const sd = this.ws?.skillDamage;
-    return sd?.get(this.skills[0].id) ?? this.skills[0].totalDamage;
+    return sd ? (sd.get(this.skills[0].id) ?? 0) : this.skills[0].totalDamage;
   });
 
   skillDamagePercentages = $derived.by(() => {
     const sd = this.ws?.skillDamage;
     return this.skills.map((skill) => {
-      const dmg = sd?.get(skill.id) ?? skill.totalDamage;
-      return (dmg / this.mostDamageSkill) * 100;
+      const dmg = sd ? (sd.get(skill.id) ?? 0) : skill.totalDamage;
+      return this.mostDamageSkill > 0 ? (dmg / this.mostDamageSkill) * 100 : 0;
     });
   });
   anyBackAttacks = $derived(this.skills.some((skill) => skill.backAttacks > 0));

--- a/src/lib/entity.svelte.ts
+++ b/src/lib/entity.svelte.ts
@@ -160,18 +160,28 @@ export class EntityState {
 
   skills = $derived.by(() => {
     if (!this.entity) return [];
-    if (this.entity && this.entity.class === "Arcanist") {
-      return Object.values(this.entity.skills)
-        .sort((a, b) => b.totalDamage - a.totalDamage)
-        .filter((skill) => !cardIds.includes(skill.id));
-    } else {
-      return Object.values(this.entity.skills).sort((a, b) => b.totalDamage - a.totalDamage);
+    const sd = this.ws?.skillDamage;
+    const dmg = (s: { id: number; totalDamage: number }) => sd?.get(s.id) ?? s.totalDamage;
+    let arr = Object.values(this.entity.skills);
+    if (this.entity.class === "Arcanist") {
+      arr = arr.filter((skill) => !cardIds.includes(skill.id));
     }
+    return arr.sort((a, b) => dmg(b) - dmg(a));
   });
 
-  mostDamageSkill = $derived(this.skills[0]?.totalDamage ?? 0);
+  mostDamageSkill = $derived.by(() => {
+    if (this.skills.length === 0) return 0;
+    const sd = this.ws?.skillDamage;
+    return sd?.get(this.skills[0].id) ?? this.skills[0].totalDamage;
+  });
 
-  skillDamagePercentages = $derived(this.skills.map((skill) => (skill.totalDamage / this.mostDamageSkill) * 100));
+  skillDamagePercentages = $derived.by(() => {
+    const sd = this.ws?.skillDamage;
+    return this.skills.map((skill) => {
+      const dmg = sd?.get(skill.id) ?? skill.totalDamage;
+      return (dmg / this.mostDamageSkill) * 100;
+    });
+  });
   anyBackAttacks = $derived(this.skills.some((skill) => skill.backAttacks > 0));
   anyFrontAttacks = $derived(this.skills.some((skill) => skill.frontAttacks > 0));
   anySupportBuff = $derived(this.skills.some((skill) => skill.buffedBySupport > 0));

--- a/src/lib/entity.svelte.ts
+++ b/src/lib/entity.svelte.ts
@@ -5,10 +5,14 @@ import { sumRdpsContributed } from "./skill.svelte";
 import { settings } from "./stores.svelte";
 import { type Entity, EntityType, type IncapacitatedEvent } from "./types";
 import { hyperAwakeningIds } from "./utils/buffs";
+import type { WindowedEntityStats } from "./utils/windowedStats";
 
 export class EntityState {
   entity: Entity = $state()!;
   encounter: EncounterState = $state()!;
+
+  ws: WindowedEntityStats | undefined = $derived(this.encounter.windowedStats?.get(this.entity.name));
+  wDurMs: number = $derived(this.encounter.windowDurationMs);
 
   name: string = $derived.by(() => {
     if (!this.entity) return "";
@@ -35,6 +39,7 @@ export class EntityState {
   });
 
   dps = $derived.by(() => {
+    if (this.ws) return this.ws.dps;
     if (this.encounter.live) {
       return Math.round(this.entity.damageStats.damageDealt / (this.encounter.duration / 1000));
     } else {
@@ -50,20 +55,25 @@ export class EntityState {
     }
   });
 
-  damageDealt = $derived(this.entity.damageStats.damageDealt);
+  damageDealt = $derived(this.ws?.damageDealt ?? this.entity.damageStats.damageDealt);
   damageDealtString = $derived(abbreviateNumberSplit(this.damageDealt));
   damageDealtWithoutSpecial = $derived(
-    this.damageDealt -
-      Object.values(this.entity.skills)
-        .filter((skill) => skill.special)
-        .reduce((acc, skill) => acc + skill.totalDamage, 0)
+    this.ws
+      ? this.ws.damageDealt - this.ws.specialDamage
+      : this.damageDealt -
+          Object.values(this.entity.skills)
+            .filter((skill) => skill.special)
+            .reduce((acc, skill) => acc + skill.totalDamage, 0)
   );
   damageDealtWithoutSpecialOrHa = $derived(
-    this.damageDealtWithoutSpecial - (this.entity.damageStats.hyperAwakeningDamage ?? 0)
+    this.ws
+      ? this.damageDealtWithoutSpecial - this.ws.hyperAwakeningDamage
+      : this.damageDealtWithoutSpecial - (this.entity.damageStats.hyperAwakeningDamage ?? 0)
   );
   damagePercentage = $derived(((this.damageDealt / this.encounter.totalDamageDealt) * 100).toFixed(1));
   damageTakenString = $derived(abbreviateNumberSplit(this.entity.damageStats.damageTaken));
   unbuffedDps = $derived.by(() => {
+    if (this.ws) return this.ws.unbuffedDps;
     if (this.encounter.live) {
       if (this.entity.damageStats.unbuffedDamage === 0) return this.dps;
       return Math.round(this.entity.damageStats.unbuffedDamage / (this.encounter.duration / 1000));
@@ -73,53 +83,68 @@ export class EntityState {
   });
 
   hitsWithoutSpecial = $derived(
-    this.entity.skillStats.hits -
-      Object.values(this.entity.skills)
-        .filter((skill) => skill.special || skill.isHyperAwakening || hyperAwakeningIds.has(skill.id))
-        .reduce((acc, skill) => acc + skill.hits, 0)
+    this.ws
+      ? this.ws.hits - this.ws.hitsSpecialOrHa
+      : this.entity.skillStats.hits -
+          Object.values(this.entity.skills)
+            .filter((skill) => skill.special || skill.isHyperAwakening || hyperAwakeningIds.has(skill.id))
+            .reduce((acc, skill) => acc + skill.hits, 0)
   );
 
   deadFor: string = $derived.by(() => {
-    if (this.entity.isDead) {
-      return Math.abs((this.encounter.end - this.entity.damageStats.deathTime) / 1000).toFixed(0) + "s";
+    if (!this.entity.isDead) return "";
+    const deathTime = this.entity.damageStats.deathTime;
+    const tw = this.encounter.timeWindow;
+    if (tw && this.encounter.encounter) {
+      const fightStart = this.encounter.encounter.fightStart;
+      const windowStart = fightStart + tw.startMs;
+      const windowEnd = fightStart + tw.endMs;
+      if (deathTime >= windowEnd) return "";
+      if (deathTime < windowStart) return (this.wDurMs / 1000).toFixed(0) + "s";
+      return ((windowEnd - deathTime) / 1000).toFixed(0) + "s";
     }
-    return "";
+    return Math.abs((this.encounter.end - deathTime) / 1000).toFixed(0) + "s";
   });
 
   critPercentage = $derived.by(() => {
     if (this.hitsWithoutSpecial > 0) {
-      return customRound((this.entity.skillStats.crits / this.hitsWithoutSpecial) * 100);
+      const crits = this.ws?.crits ?? this.entity.skillStats.crits;
+      return customRound((crits / this.hitsWithoutSpecial) * 100);
     }
     return "0";
   });
   critDmgPercentage = $derived.by(() => {
     if (this.hitsWithoutSpecial > 0) {
-      return customRound((this.entity.damageStats.critDamage / this.damageDealtWithoutSpecialOrHa) * 100);
+      const critDamage = this.ws?.critDamage ?? this.entity.damageStats.critDamage;
+      return customRound((critDamage / this.damageDealtWithoutSpecialOrHa) * 100);
     }
     return "0";
   });
   baPercentage = $derived.by(() => {
     if (this.hitsWithoutSpecial > 0) {
-      return customRound((this.entity.skillStats.backAttacks / this.hitsWithoutSpecial) * 100);
+      const ba = this.ws?.backAttacks ?? this.entity.skillStats.backAttacks;
+      return customRound((ba / this.hitsWithoutSpecial) * 100);
     }
-
     return "0";
   });
   badPercentage = $derived.by(() => {
-    if (this.entity.damageStats.backAttackDamage > 0) {
-      return customRound((this.entity.damageStats.backAttackDamage / this.damageDealtWithoutSpecialOrHa) * 100);
+    const bad = this.ws?.backAttackDamage ?? this.entity.damageStats.backAttackDamage;
+    if (bad > 0) {
+      return customRound((bad / this.damageDealtWithoutSpecialOrHa) * 100);
     }
     return "0";
   });
   faPercentage = $derived.by(() => {
     if (this.hitsWithoutSpecial > 0) {
-      return customRound((this.entity.skillStats.frontAttacks / this.hitsWithoutSpecial) * 100);
+      const fa = this.ws?.frontAttacks ?? this.entity.skillStats.frontAttacks;
+      return customRound((fa / this.hitsWithoutSpecial) * 100);
     }
     return "0";
   });
   fadPercentage = $derived.by(() => {
-    if (this.entity.damageStats.frontAttackDamage > 0) {
-      return customRound((this.entity.damageStats.frontAttackDamage / this.damageDealtWithoutSpecialOrHa) * 100);
+    const fad = this.ws?.frontAttackDamage ?? this.entity.damageStats.frontAttackDamage;
+    if (fad > 0) {
+      return customRound((fad / this.damageDealtWithoutSpecialOrHa) * 100);
     }
     return "0";
   });
@@ -155,10 +180,18 @@ export class EntityState {
   anySupportHat = $derived(this.skills.some((skill) => skill.buffedByHat > 0));
 
   anyCooldownRatio = $derived(this.skills.some((skill) => skill.timeAvailable));
-  anyStagger = $derived(this.entity.damageStats.stagger > 0);
+  // Windowed-aware accessors for fields read directly in templates
+  buffedBySupport = $derived(this.ws?.buffedBySupport ?? this.entity.damageStats.buffedBySupport);
+  debuffedBySupport = $derived(this.ws?.debuffedBySupport ?? this.entity.damageStats.debuffedBySupport);
+  buffedByIdentity = $derived(this.ws?.buffedByIdentity ?? this.entity.damageStats.buffedByIdentity);
+  buffedByHat = $derived(this.ws?.buffedByHat ?? (this.entity.damageStats.buffedByHat ?? 0));
+  stagger = $derived(this.ws?.stagger ?? this.entity.damageStats.stagger);
+  unbuffedDamage = $derived(this.ws?.unbuffedDamage ?? this.entity.damageStats.unbuffedDamage);
+  deaths = $derived(this.ws?.deaths ?? this.entity.damageStats.deaths);
+
+  anyStagger = $derived(this.stagger > 0);
   anyUnbuffedDamage = $derived(
-    this.entity.damageStats.unbuffedDamage > 0 &&
-      this.entity.damageStats.unbuffedDamage !== this.entity.damageStats.damageDealt
+    this.unbuffedDamage > 0 && this.unbuffedDamage !== this.damageDealt
   );
 
   hasRdpsContributions = $derived(

--- a/src/lib/entity.svelte.ts
+++ b/src/lib/entity.svelte.ts
@@ -160,8 +160,8 @@ export class EntityState {
 
   skills = $derived.by(() => {
     if (!this.entity) return [];
-    const sd = this.ws?.skillDamage;
-    const dmg = (s: { id: number; totalDamage: number }) => sd ? (sd.get(s.id) ?? 0) : s.totalDamage;
+    const ss = this.ws?.skillStats;
+    const dmg = (s: { id: number; totalDamage: number }) => ss ? (ss.get(s.id)?.totalDamage ?? 0) : s.totalDamage;
     let arr = Object.values(this.entity.skills);
     if (this.entity.class === "Arcanist") {
       arr = arr.filter((skill) => !cardIds.includes(skill.id));
@@ -171,14 +171,14 @@ export class EntityState {
 
   mostDamageSkill = $derived.by(() => {
     if (this.skills.length === 0) return 0;
-    const sd = this.ws?.skillDamage;
-    return sd ? (sd.get(this.skills[0].id) ?? 0) : this.skills[0].totalDamage;
+    const ss = this.ws?.skillStats;
+    return ss ? (ss.get(this.skills[0].id)?.totalDamage ?? 0) : this.skills[0].totalDamage;
   });
 
   skillDamagePercentages = $derived.by(() => {
-    const sd = this.ws?.skillDamage;
+    const ss = this.ws?.skillStats;
     return this.skills.map((skill) => {
-      const dmg = sd ? (sd.get(skill.id) ?? 0) : skill.totalDamage;
+      const dmg = ss ? (ss.get(skill.id)?.totalDamage ?? 0) : skill.totalDamage;
       return this.mostDamageSkill > 0 ? (dmg / this.mostDamageSkill) * 100 : 0;
     });
   });

--- a/src/lib/skill.svelte.ts
+++ b/src/lib/skill.svelte.ts
@@ -2,12 +2,28 @@ import { abbreviateNumberSplit, customRound } from "$lib/utils";
 import type { EntityState } from "./entity.svelte";
 import { settings } from "./stores.svelte";
 import type { Skill } from "./types";
+import type { WindowedSkillStats } from "./utils/windowedStats";
 
 export class SkillState {
   skill: Skill = $state()!;
   entity: EntityState = $state()!;
 
+  wss: WindowedSkillStats | undefined = $derived(this.entity.ws?.skillStats.get(this.skill.id));
+
+  // windowed getters
+  totalDamage = $derived(this.wss?.totalDamage ?? this.skill.totalDamage);
+  hits = $derived(this.wss?.hits ?? this.skill.hits);
+  crits = $derived(this.wss?.crits ?? this.skill.crits);
+  critDmg = $derived(this.wss?.critDamage ?? this.skill.critDamage);
+  ba = $derived(this.wss?.backAttacks ?? this.skill.backAttacks);
+  baDmg = $derived(this.wss?.backAttackDamage ?? this.skill.backAttackDamage);
+  fa = $derived(this.wss?.frontAttacks ?? this.skill.frontAttacks);
+  faDmg = $derived(this.wss?.frontAttackDamage ?? this.skill.frontAttackDamage);
+  casts = $derived(this.wss?.casts ?? this.skill.casts);
+  maxDmg = $derived(this.wss?.maxDamage ?? this.skill.maxDamage);
+
   skillDps = $derived.by(() => {
+    if (this.wss) return this.wss.dps;
     if (this.entity.encounter.live) {
       return Math.round(this.skill.totalDamage / (this.entity.encounter.duration / 1000));
     } else {
@@ -15,13 +31,12 @@ export class SkillState {
     }
   });
   skillDpsString = $derived(abbreviateNumberSplit(this.skillDps));
-  skillDamageString = $derived(abbreviateNumberSplit(this.skill.totalDamage));
-  skillUnbuffedDamage = $derived(this.skill.totalDamage - sumRdpsReceived(this.skill, [1, 3, 5]));
+  skillDamageString = $derived(abbreviateNumberSplit(this.totalDamage));
+  skillUnbuffedDamage = $derived(this.totalDamage - sumRdpsReceived(this.skill, [1, 3, 5]));
   skillUnbuffedDps = $derived.by(() => {
-    // the dps calculated here can slightly differ from one calculated in backend (prolly due to time/rounding? idk)
-    // so returning pre-calculated dps if unbuffed damage equals total damage
-    if (this.skillUnbuffedDamage === 0 || this.skillUnbuffedDamage === this.skill.totalDamage) return this.skillDps;
-    return Math.round(this.skillUnbuffedDamage / (this.entity.encounter.duration / 1000));
+    if (this.skillUnbuffedDamage === 0 || this.skillUnbuffedDamage === this.totalDamage) return this.skillDps;
+    const dur = this.wss ? this.entity.wDurMs : this.entity.encounter.duration;
+    return Math.round(this.skillUnbuffedDamage / (dur / 1000));
   });
   skillUnbuffedDamageString = $derived(abbreviateNumberSplit(this.skillUnbuffedDamage));
   skillUnbuffedDpsString = $derived(abbreviateNumberSplit(this.skillUnbuffedDps));
@@ -30,59 +45,64 @@ export class SkillState {
 
   skillBuffedDps = $derived.by(() => {
     if (this.skillBuffedDamage === 0) return 0;
-    return Math.round(this.skillBuffedDamage / (this.entity.encounter.duration / 1000));
+    const dur = this.wss ? this.entity.wDurMs : this.entity.encounter.duration;
+    return Math.round(this.skillBuffedDamage / (dur / 1000));
   });
 
   skillDamageReduced = $derived(sumRdpsContributed(this.skill, [4, 6]));
 
   critPercentage = $derived.by(() => {
-    if (this.skill.hits > 0) {
-      return customRound((this.skill.crits / this.skill.hits) * 100);
+    if (this.hits > 0) {
+      return customRound((this.crits / this.hits) * 100);
     }
     return "0";
   });
   critDmgPercentage = $derived.by(() => {
-    if (this.skill.hits > 0 && this.skill.totalDamage > 0) {
-      return customRound((this.skill.critDamage / this.skill.totalDamage) * 100);
+    if (this.hits > 0 && this.totalDamage > 0) {
+      return customRound((this.critDmg / this.totalDamage) * 100);
     }
     return "0";
   });
   baPercentage = $derived.by(() => {
-    if (this.skill.hits > 0) {
-      return customRound((this.skill.backAttacks / this.skill.hits) * 100);
+    if (this.hits > 0) {
+      return customRound((this.ba / this.hits) * 100);
     }
     return "0";
   });
   badPercentage = $derived.by(() => {
-    if (this.skill.backAttackDamage > 0) {
-      return customRound((this.skill.backAttackDamage / this.skill.totalDamage) * 100);
+    if (this.baDmg > 0) {
+      return customRound((this.baDmg / this.totalDamage) * 100);
     }
     return "0";
   });
   faPercentage = $derived.by(() => {
-    if (this.skill.hits > 0) {
-      return customRound((this.skill.frontAttacks / this.skill.hits) * 100);
+    if (this.hits > 0) {
+      return customRound((this.fa / this.hits) * 100);
     }
     return "0";
   });
   fadPercentage = $derived.by(() => {
-    if (this.skill.frontAttackDamage > 0) {
-      return customRound((this.skill.frontAttackDamage / this.skill.totalDamage) * 100);
+    if (this.faDmg > 0) {
+      return customRound((this.faDmg / this.totalDamage) * 100);
     }
     return "0";
   });
-  averagePerCast = $derived(this.skill.totalDamage / this.skill.casts);
+  averagePerCast = $derived(this.casts > 0 ? this.totalDamage / this.casts : 0);
   adjustedCrit = $derived.by(() => {
     if (settings.app.logs.breakdown.adjustedCritRate) {
-      if (this.skill.adjustedCrit) {
+      if (this.skill.adjustedCrit && !this.wss) {
         return customRound(this.skill.adjustedCrit * 100);
       } else {
         const filter = this.averagePerCast * 0.05;
         let adjustedCrits = 0;
         let adjustedHits = 0;
         if (this.skill.skillCastLog.length > 0) {
+          const ws = this.entity.ws;
+          const windowStartMs = ws ? this.entity.encounter.timeWindow?.startMs ?? 0 : 0;
+          const windowEndMs = ws ? this.entity.encounter.timeWindow?.endMs ?? Infinity : Infinity;
           for (const c of this.skill.skillCastLog) {
             for (const h of c.hits) {
+              if (ws && (h.timestamp < windowStartMs || h.timestamp >= windowEndMs)) continue;
               if (h.damage > filter) {
                 adjustedCrits += h.crit ? 1 : 0;
                 adjustedHits += 1;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -294,6 +294,7 @@ export interface SkillChartSupportDamage {
   buff: number;
   brand: number;
   identity: number;
+  hat: number;
 }
 
 export interface SkillChartModInfo {

--- a/src/lib/utils/buffs.ts
+++ b/src/lib/utils/buffs.ts
@@ -481,13 +481,13 @@ export function getSkillCastBuffs(
 }
 
 export function getSkillCastSupportBuffs(hit: SkillHit, encounterDamageStats: EncounterDamageStats) {
-  const supportBuffs: SkillChartSupportDamage = { buff: 0, brand: 0, identity: 0 };
+  const supportBuffs: SkillChartSupportDamage = { buff: 0, brand: 0, identity: 0, hat: 0 };
 
   for (const type of buffTypes) {
     for (const buffId of (hit as any)[type.key1]) {
       const buffs = (encounterDamageStats as any)[type.key2];
       if (buffs.hasOwnProperty(buffId)) {
-        if (supportBuffs.brand > 0 && supportBuffs.buff > 0 && supportBuffs.identity > 0) {
+        if (supportBuffs.brand > 0 && supportBuffs.buff > 0 && supportBuffs.identity > 0 && supportBuffs.hat > 0) {
           return supportBuffs;
         }
         getHitSupportBuffs(hit.damage, buffs[buffId], supportBuffs);
@@ -518,6 +518,8 @@ function getHitSupportBuffs(hitDamage: number, buff: StatusEffect, supportBuffs:
       supportBuffs.brand += hitDamage;
     } else if (key.includes("_2_") && !supportBuffs.identity) {
       supportBuffs.identity += hitDamage;
+    } else if (key.includes("_3_") && !supportBuffs.hat) {
+      supportBuffs.hat += hitDamage;
     }
   }
 }

--- a/src/lib/utils/buffs.ts
+++ b/src/lib/utils/buffs.ts
@@ -147,9 +147,18 @@ export function filterStatusEffects(
   }
 }
 
-export function getSynergyPercentageDetails(groupedSynergies: Map<string, Map<number, StatusEffect>>, skill: Skill) {
+export function getSynergyPercentageDetails(
+  groupedSynergies: Map<string, Map<number, StatusEffect>>,
+  skill: Skill,
+  entityState?: EntityState
+) {
   const synergyPercentageDetails: BuffDetails[] = [];
   const isHyperAwakening = skill.isHyperAwakening || hyperAwakeningIds.has(skill.id);
+  const ws = entityState?.ws;
+  const emptyBuffs: { [key: number]: number } = {};
+  const sBuffedBy = ws ? (ws.skillBuffedBy.get(skill.id) ?? emptyBuffs) : skill.buffedBy;
+  const sDebuffedBy = ws ? (ws.skillDebuffedBy.get(skill.id) ?? emptyBuffs) : skill.debuffedBy;
+  const sTotalDamage = ws ? (ws.skillDamage.get(skill.id) ?? 0) : skill.totalDamage;
   groupedSynergies.forEach((synergies, key) => {
     let synergyDamage = 0;
     const buff = new BuffDetails();
@@ -164,40 +173,40 @@ export function getSynergyPercentageDetails(groupedSynergies: Map<string, Map<nu
         if (supportSkills.haTechnique.includes(id) || supportSkills.hyperHat.includes(id)) {
           const b = new Buff(
             syn.source.icon,
-            customRound((skill.buffedBy[id] / skill.totalDamage) * 100),
+            customRound(((sBuffedBy[id] ?? 0) / sTotalDamage) * 100),
             syn.source.skill?.icon
           );
 
           buff.buffs.push(b);
-          synergyDamage += skill.buffedBy[id];
+          synergyDamage += sBuffedBy[id] ?? 0;
         }
 
         return;
       }
 
-      if (skill.buffedBy[id]) {
+      if (sBuffedBy[id]) {
         const b = new Buff(
           syn.source.icon,
-          customRound((skill.buffedBy[id] / skill.totalDamage) * 100),
+          customRound((sBuffedBy[id] / sTotalDamage) * 100),
           syn.source.skill?.icon
         );
         addBardBubbles(key, b, syn);
         buff.buffs.push(b);
-        synergyDamage += skill.buffedBy[id];
-      } else if (skill.debuffedBy[id]) {
+        synergyDamage += sBuffedBy[id];
+      } else if (sDebuffedBy[id]) {
         buff.buffs.push(
           new Buff(
             syn.source.icon,
-            customRound((skill.debuffedBy[id] / skill.totalDamage) * 100),
+            customRound((sDebuffedBy[id] / sTotalDamage) * 100),
             syn.source.skill?.icon
           )
         );
-        synergyDamage += skill.debuffedBy[id];
+        synergyDamage += sDebuffedBy[id];
       }
     });
 
     if (synergyDamage > 0) {
-      buff.percentage = customRound((synergyDamage / skill.totalDamage) * 100);
+      buff.percentage = customRound((synergyDamage / sTotalDamage) * 100);
     }
     synergyPercentageDetails.push(buff);
   });
@@ -210,6 +219,7 @@ export function getSynergyPercentageDetailsSum(
   entityState: EntityState
 ) {
   const synergyPercentageDetails: BuffDetails[] = [];
+  const ws = entityState.ws;
   groupedSynergies.forEach((synergies, key) => {
     let synergyDamage = 0;
     const buffs = new BuffDetails();
@@ -229,13 +239,16 @@ export function getSynergyPercentageDetailsSum(
         if ((skill.isHyperAwakening || hyperAwakeningIds.has(skill.id)) && !isHat) {
           continue;
         }
-        if (skill.buffedBy[id]) {
-          totalBuffed += skill.buffedBy[id];
-          synergyDamage += skill.buffedBy[id];
+        const emptyBuffs: { [key: number]: number } = {};
+        const sBuffedBy = ws ? (ws.skillBuffedBy.get(skill.id) ?? emptyBuffs) : skill.buffedBy;
+        const sDebuffedBy = ws ? (ws.skillDebuffedBy.get(skill.id) ?? emptyBuffs) : skill.debuffedBy;
+        if (sBuffedBy[id]) {
+          totalBuffed += sBuffedBy[id];
+          synergyDamage += sBuffedBy[id];
         }
-        if (skill.debuffedBy[id]) {
-          totalBuffed += skill.debuffedBy[id];
-          synergyDamage += skill.debuffedBy[id];
+        if (sDebuffedBy[id]) {
+          totalBuffed += sDebuffedBy[id];
+          synergyDamage += sDebuffedBy[id];
         }
       }
       if (isHat) {

--- a/src/lib/utils/buffs.ts
+++ b/src/lib/utils/buffs.ts
@@ -154,11 +154,11 @@ export function getSynergyPercentageDetails(
 ) {
   const synergyPercentageDetails: BuffDetails[] = [];
   const isHyperAwakening = skill.isHyperAwakening || hyperAwakeningIds.has(skill.id);
-  const ws = entityState?.ws;
+  const wss = entityState?.ws?.skillStats.get(skill.id);
   const emptyBuffs: { [key: number]: number } = {};
-  const sBuffedBy = ws ? (ws.skillBuffedBy.get(skill.id) ?? emptyBuffs) : skill.buffedBy;
-  const sDebuffedBy = ws ? (ws.skillDebuffedBy.get(skill.id) ?? emptyBuffs) : skill.debuffedBy;
-  const sTotalDamage = ws ? (ws.skillDamage.get(skill.id) ?? 0) : skill.totalDamage;
+  const sBuffedBy = wss ? (wss.buffedBy ?? emptyBuffs) : skill.buffedBy;
+  const sDebuffedBy = wss ? (wss.debuffedBy ?? emptyBuffs) : skill.debuffedBy;
+  const sTotalDamage = wss ? wss.totalDamage : skill.totalDamage;
   groupedSynergies.forEach((synergies, key) => {
     let synergyDamage = 0;
     const buff = new BuffDetails();
@@ -240,8 +240,9 @@ export function getSynergyPercentageDetailsSum(
           continue;
         }
         const emptyBuffs: { [key: number]: number } = {};
-        const sBuffedBy = ws ? (ws.skillBuffedBy.get(skill.id) ?? emptyBuffs) : skill.buffedBy;
-        const sDebuffedBy = ws ? (ws.skillDebuffedBy.get(skill.id) ?? emptyBuffs) : skill.debuffedBy;
+        const wss = ws?.skillStats.get(skill.id);
+        const sBuffedBy = wss ? (wss.buffedBy ?? emptyBuffs) : skill.buffedBy;
+        const sDebuffedBy = wss ? (wss.debuffedBy ?? emptyBuffs) : skill.debuffedBy;
         if (sBuffedBy[id]) {
           totalBuffed += sBuffedBy[id];
           synergyDamage += sBuffedBy[id];

--- a/src/lib/utils/dpsCharts.ts
+++ b/src/lib/utils/dpsCharts.ts
@@ -326,7 +326,8 @@ export function getDetailedSkillLogChart(
         },
         moveHandleStyle: {
           color: "rgba(136,136,136)"
-        }
+        },
+        moveHandleSize: 0
       },
       {
         type: "inside",
@@ -518,7 +519,8 @@ export function getBasicSkillLogChart(
         },
         moveHandleStyle: {
           color: "rgba(136,136,136)"
-        }
+        },
+        moveHandleSize: 0
       },
       {
         type: "inside",
@@ -740,7 +742,7 @@ function skillCastBreakdownTooltip(
         </thead>
         <tbody>
     `;
-  const totalSupBuffs: SkillChartSupportDamage = { buff: 0, brand: 0, identity: 0 };
+  const totalSupBuffs: SkillChartSupportDamage = { buff: 0, brand: 0, identity: 0, hat: 0 };
   const modInfo: SkillChartModInfo = { crit: 0, critDamage: 0, ba: 0, fa: 0 };
   for (const [i, hit] of skillCast.hits.entries()) {
     const groupedBuffs = getSkillCastBuffs(hit, encounterDamageStats, player);

--- a/src/lib/utils/windowedStats.ts
+++ b/src/lib/utils/windowedStats.ts
@@ -1,6 +1,23 @@
 import { getSkillCastSupportBuffs, hyperAwakeningIds } from "$lib/utils/buffs";
 import type { Encounter, Entity } from "$lib/types";
 
+export interface WindowedSkillStats {
+  totalDamage: number;
+  dps: number;
+  hits: number;
+  casts: number;
+  crits: number;
+  critDamage: number;
+  backAttacks: number;
+  backAttackDamage: number;
+  frontAttacks: number;
+  frontAttackDamage: number;
+  buffedBy: { [key: number]: number };
+  debuffedBy: { [key: number]: number };
+  maxDamage: number;
+  stagger: number;
+}
+
 export interface WindowedEntityStats {
   // DamageStats overrides
   damageDealt: number;
@@ -26,12 +43,30 @@ export interface WindowedEntityStats {
   backAttacks: number;
   frontAttacks: number;
   hitsSpecialOrHa: number; // for hitsWithoutSpecial denominator
-  skillDamage: Map<number, number>; // skillId -> totalDamage in window
-  // per-buff damage (mirrors entity.damageStats.buffedBy/debuffedBy and skill.buffedBy/debuffedBy)
+  // per-buff damage (mirrors entity.damageStats.buffedBy/debuffedBy)
   buffedBy: { [key: number]: number };
   debuffedBy: { [key: number]: number };
-  skillBuffedBy: Map<number, { [key: number]: number }>; // skillId -> buffId -> damage
-  skillDebuffedBy: Map<number, { [key: number]: number }>; // skillId -> buffId -> damage
+  // per-skill stats
+  skillStats: Map<number, WindowedSkillStats>;
+}
+
+function newSkillStats(): WindowedSkillStats {
+  return {
+    totalDamage: 0,
+    dps: 0,
+    hits: 0,
+    casts: 0,
+    crits: 0,
+    critDamage: 0,
+    backAttacks: 0,
+    backAttackDamage: 0,
+    frontAttacks: 0,
+    frontAttackDamage: 0,
+    buffedBy: {},
+    debuffedBy: {},
+    maxDamage: 0,
+    stagger: 0
+  };
 }
 
 export function computeWindowedEntityStats(
@@ -64,11 +99,9 @@ export function computeWindowedEntityStats(
     backAttacks: 0,
     frontAttacks: 0,
     hitsSpecialOrHa: 0,
-    skillDamage: new Map(),
     buffedBy: {},
     debuffedBy: {},
-    skillBuffedBy: new Map(),
-    skillDebuffedBy: new Map()
+    skillStats: new Map()
   };
 
   const fightStart = encounter.fightStart;
@@ -81,28 +114,50 @@ export function computeWindowedEntityStats(
     const isSpecial = skill.special === true;
     const isHa = skill.isHyperAwakening || hyperAwakeningIds.has(skill.id);
 
+    let ss: WindowedSkillStats | undefined;
+
     for (const cast of skill.skillCastLog) {
+      let castHadHitInWindow = false;
+
       for (const hit of cast.hits) {
         if (hit.timestamp < windowStartMs || hit.timestamp >= windowEndMs) continue;
 
+        if (!ss) {
+          ss = newSkillStats();
+          result.skillStats.set(skill.id, ss);
+        }
+
+        castHadHitInWindow = true;
+
         result.damageDealt += hit.damage;
-        result.skillDamage.set(skill.id, (result.skillDamage.get(skill.id) ?? 0) + hit.damage);
         result.unbuffedDamage += hit.unbuffedDamage ?? hit.damage;
         result.rdpsDamageReceived += hit.rdpsDamageReceived;
         result.rdpsDamageReceivedSupport += hit.rdpsDamageReceivedSupport;
         result.hits++;
 
+        // per-skill stats
+        ss.totalDamage += hit.damage;
+        ss.hits++;
+        if (hit.damage > ss.maxDamage) ss.maxDamage = hit.damage;
+        ss.stagger += hit.stagger ?? 0;
+
         if (hit.crit) {
           result.crits++;
           result.critDamage += hit.damage;
+          ss.crits++;
+          ss.critDamage += hit.damage;
         }
         if (hit.backAttack) {
           result.backAttacks++;
           result.backAttackDamage += hit.damage;
+          ss.backAttacks++;
+          ss.backAttackDamage += hit.damage;
         }
         if (hit.frontAttack) {
           result.frontAttacks++;
           result.frontAttackDamage += hit.damage;
+          ss.frontAttacks++;
+          ss.frontAttackDamage += hit.damage;
         }
         if (hit.stagger) {
           result.stagger += hit.stagger;
@@ -126,17 +181,23 @@ export function computeWindowedEntityStats(
         // per-buff damage for buff percentage calculations
         for (const buffId of hit.buffedBy) {
           result.buffedBy[buffId] = (result.buffedBy[buffId] ?? 0) + hit.damage;
-          let sb = result.skillBuffedBy.get(skill.id);
-          if (!sb) { sb = {}; result.skillBuffedBy.set(skill.id, sb); }
-          sb[buffId] = (sb[buffId] ?? 0) + hit.damage;
+          ss.buffedBy[buffId] = (ss.buffedBy[buffId] ?? 0) + hit.damage;
         }
         for (const buffId of hit.debuffedBy) {
           result.debuffedBy[buffId] = (result.debuffedBy[buffId] ?? 0) + hit.damage;
-          let sd = result.skillDebuffedBy.get(skill.id);
-          if (!sd) { sd = {}; result.skillDebuffedBy.set(skill.id, sd); }
-          sd[buffId] = (sd[buffId] ?? 0) + hit.damage;
+          ss.debuffedBy[buffId] = (ss.debuffedBy[buffId] ?? 0) + hit.damage;
         }
       }
+
+      if (castHadHitInWindow && ss) {
+        ss.casts++;
+      }
+    }
+
+    // compute per-skill dps
+    if (ss) {
+      const durationSec = windowDurationMs / 1000;
+      ss.dps = durationSec > 0 ? Math.round(ss.totalDamage / durationSec) : 0;
     }
   }
 

--- a/src/lib/utils/windowedStats.ts
+++ b/src/lib/utils/windowedStats.ts
@@ -26,6 +26,7 @@ export interface WindowedEntityStats {
   backAttacks: number;
   frontAttacks: number;
   hitsSpecialOrHa: number; // for hitsWithoutSpecial denominator
+  skillDamage: Map<number, number>; // skillId -> totalDamage in window
 }
 
 export function computeWindowedEntityStats(
@@ -57,7 +58,8 @@ export function computeWindowedEntityStats(
     crits: 0,
     backAttacks: 0,
     frontAttacks: 0,
-    hitsSpecialOrHa: 0
+    hitsSpecialOrHa: 0,
+    skillDamage: new Map()
   };
 
   const fightStart = encounter.fightStart;
@@ -75,6 +77,7 @@ export function computeWindowedEntityStats(
         if (hit.timestamp < windowStartMs || hit.timestamp >= windowEndMs) continue;
 
         result.damageDealt += hit.damage;
+        result.skillDamage.set(skill.id, (result.skillDamage.get(skill.id) ?? 0) + hit.damage);
         result.unbuffedDamage += hit.unbuffedDamage ?? hit.damage;
         result.rdpsDamageReceived += hit.rdpsDamageReceived;
         result.rdpsDamageReceivedSupport += hit.rdpsDamageReceivedSupport;

--- a/src/lib/utils/windowedStats.ts
+++ b/src/lib/utils/windowedStats.ts
@@ -27,6 +27,11 @@ export interface WindowedEntityStats {
   frontAttacks: number;
   hitsSpecialOrHa: number; // for hitsWithoutSpecial denominator
   skillDamage: Map<number, number>; // skillId -> totalDamage in window
+  // per-buff damage (mirrors entity.damageStats.buffedBy/debuffedBy and skill.buffedBy/debuffedBy)
+  buffedBy: { [key: number]: number };
+  debuffedBy: { [key: number]: number };
+  skillBuffedBy: Map<number, { [key: number]: number }>; // skillId -> buffId -> damage
+  skillDebuffedBy: Map<number, { [key: number]: number }>; // skillId -> buffId -> damage
 }
 
 export function computeWindowedEntityStats(
@@ -59,7 +64,11 @@ export function computeWindowedEntityStats(
     backAttacks: 0,
     frontAttacks: 0,
     hitsSpecialOrHa: 0,
-    skillDamage: new Map()
+    skillDamage: new Map(),
+    buffedBy: {},
+    debuffedBy: {},
+    skillBuffedBy: new Map(),
+    skillDebuffedBy: new Map()
   };
 
   const fightStart = encounter.fightStart;
@@ -113,6 +122,20 @@ export function computeWindowedEntityStats(
         result.debuffedBySupport += supportBuffs.brand;
         result.buffedByIdentity += supportBuffs.identity;
         result.buffedByHat += supportBuffs.hat;
+
+        // per-buff damage for buff percentage calculations
+        for (const buffId of hit.buffedBy) {
+          result.buffedBy[buffId] = (result.buffedBy[buffId] ?? 0) + hit.damage;
+          let sb = result.skillBuffedBy.get(skill.id);
+          if (!sb) { sb = {}; result.skillBuffedBy.set(skill.id, sb); }
+          sb[buffId] = (sb[buffId] ?? 0) + hit.damage;
+        }
+        for (const buffId of hit.debuffedBy) {
+          result.debuffedBy[buffId] = (result.debuffedBy[buffId] ?? 0) + hit.damage;
+          let sd = result.skillDebuffedBy.get(skill.id);
+          if (!sd) { sd = {}; result.skillDebuffedBy.set(skill.id, sd); }
+          sd[buffId] = (sd[buffId] ?? 0) + hit.damage;
+        }
       }
     }
   }

--- a/src/lib/utils/windowedStats.ts
+++ b/src/lib/utils/windowedStats.ts
@@ -1,0 +1,131 @@
+import { getSkillCastSupportBuffs, hyperAwakeningIds } from "$lib/utils/buffs";
+import type { Encounter, Entity } from "$lib/types";
+
+export interface WindowedEntityStats {
+  // DamageStats overrides
+  damageDealt: number;
+  dps: number;
+  unbuffedDamage: number;
+  unbuffedDps: number;
+  critDamage: number;
+  backAttackDamage: number;
+  frontAttackDamage: number;
+  buffedBySupport: number;
+  buffedByIdentity: number;
+  debuffedBySupport: number;
+  buffedByHat: number;
+  hyperAwakeningDamage: number;
+  specialDamage: number; // for damageDealtWithoutSpecial
+  stagger: number;
+  rdpsDamageReceived: number;
+  rdpsDamageReceivedSupport: number;
+  deaths: number;
+  // SkillStats overrides
+  hits: number;
+  crits: number;
+  backAttacks: number;
+  frontAttacks: number;
+  hitsSpecialOrHa: number; // for hitsWithoutSpecial denominator
+}
+
+export function computeWindowedEntityStats(
+  entity: Entity,
+  encounter: Encounter,
+  windowStartMs: number, // relative to fightStart
+  windowEndMs: number,
+  windowDurationMs: number
+): WindowedEntityStats {
+  const result: WindowedEntityStats = {
+    damageDealt: 0,
+    dps: 0,
+    unbuffedDamage: 0,
+    unbuffedDps: 0,
+    critDamage: 0,
+    backAttackDamage: 0,
+    frontAttackDamage: 0,
+    buffedBySupport: 0,
+    buffedByIdentity: 0,
+    debuffedBySupport: 0,
+    buffedByHat: 0,
+    hyperAwakeningDamage: 0,
+    specialDamage: 0,
+    stagger: 0,
+    rdpsDamageReceived: 0,
+    rdpsDamageReceivedSupport: 0,
+    deaths: 0,
+    hits: 0,
+    crits: 0,
+    backAttacks: 0,
+    frontAttacks: 0,
+    hitsSpecialOrHa: 0
+  };
+
+  const fightStart = encounter.fightStart;
+  // hit.timestamp is relative to fightStart (ms), so compare directly against windowStartMs/windowEndMs
+  // deathInfo.deathTime is absolute, so keep fightStart-offset variants for that check
+  const absoluteWindowStart = fightStart + windowStartMs;
+  const absoluteWindowEnd = fightStart + windowEndMs;
+
+  for (const skill of Object.values(entity.skills)) {
+    const isSpecial = skill.special === true;
+    const isHa = skill.isHyperAwakening || hyperAwakeningIds.has(skill.id);
+
+    for (const cast of skill.skillCastLog) {
+      for (const hit of cast.hits) {
+        if (hit.timestamp < windowStartMs || hit.timestamp >= windowEndMs) continue;
+
+        result.damageDealt += hit.damage;
+        result.unbuffedDamage += hit.unbuffedDamage ?? hit.damage;
+        result.rdpsDamageReceived += hit.rdpsDamageReceived;
+        result.rdpsDamageReceivedSupport += hit.rdpsDamageReceivedSupport;
+        result.hits++;
+
+        if (hit.crit) {
+          result.crits++;
+          result.critDamage += hit.damage;
+        }
+        if (hit.backAttack) {
+          result.backAttacks++;
+          result.backAttackDamage += hit.damage;
+        }
+        if (hit.frontAttack) {
+          result.frontAttacks++;
+          result.frontAttackDamage += hit.damage;
+        }
+        if (hit.stagger) {
+          result.stagger += hit.stagger;
+        }
+        if (isSpecial || isHa) {
+          result.hitsSpecialOrHa++;
+        }
+        if (isSpecial) {
+          result.specialDamage += hit.damage;
+        }
+        if (isHa) {
+          result.hyperAwakeningDamage += hit.damage;
+        }
+
+        const supportBuffs = getSkillCastSupportBuffs(hit, encounter.encounterDamageStats);
+        result.buffedBySupport += supportBuffs.buff;
+        result.debuffedBySupport += supportBuffs.brand;
+        result.buffedByIdentity += supportBuffs.identity;
+        result.buffedByHat += supportBuffs.hat;
+      }
+    }
+  }
+
+  const durationSec = windowDurationMs / 1000;
+  result.dps = durationSec > 0 ? Math.round(result.damageDealt / durationSec) : 0;
+  result.unbuffedDps = durationSec > 0 ? Math.round(result.unbuffedDamage / durationSec) : 0;
+
+  // Deaths: use deathInfo timestamps when available, fall back to full-encounter count
+  if (entity.damageStats.deathInfo && entity.damageStats.deathInfo.length > 0) {
+    result.deaths = entity.damageStats.deathInfo.filter(
+      (d) => d.deathTime >= absoluteWindowStart && d.deathTime < absoluteWindowEnd
+    ).length;
+  } else {
+    result.deaths = entity.damageStats.deaths;
+  }
+
+  return result;
+}

--- a/src/routes/(app)/logs/[id]/LogDamageMeter.svelte
+++ b/src/routes/(app)/logs/[id]/LogDamageMeter.svelte
@@ -10,7 +10,9 @@
   import LogPlayerBreakdown from "$lib/components/PlayerBreakdown.svelte";
   import { EncounterState } from "$lib/encounter.svelte.js";
   import { screenshot } from "$lib/stores.svelte.js";
-  import { ChartType, type Encounter, type Entity, EntityType, MeterState, MeterTab } from "$lib/types";
+  import { bossHpMap } from "$lib/constants/encounters";
+  import { BossHpLog, ChartType, type Encounter, type Entity, EntityType, MeterState, MeterTab } from "$lib/types";
+  import { resampleData } from "$lib/utils";
   import {
     getAllDeathInfo,
     getAverageDpsChart,
@@ -40,6 +42,8 @@
   let meterState = $state(MeterState.PARTY);
   let tab = $state(MeterTab.DAMAGE);
   let chartType = $state(ChartType.AVERAGE_DPS);
+  let timeWindow: { startMs: number; endMs: number } | null = $state(null);
+  let echartsInst: ReturnType<typeof chartable>["echartsInstance"] | null = $state(null);
 
   let playerName = $state("");
   let player: Entity | undefined = $derived.by(() => {
@@ -56,6 +60,11 @@
     focusedBoss = "";
     meterState = MeterState.PARTY;
     chartType = ChartType.AVERAGE_DPS;
+    timeWindow = null;
+  });
+
+  $effect(() => {
+    enc.timeWindow = timeWindow;
   });
 
   function inspectPlayer(name: string) {
@@ -86,6 +95,31 @@
   );
   let bossHpLogs = $derived(Object.entries(encounter.encounterDamageStats.bossHpLog || {}));
   let legendNames = $derived(getLegendNames(chartablePlayers));
+  let aggregateDps = $derived.by(() => {
+    if (chartablePlayers.length === 0) return [];
+    const len = chartablePlayers[0].damageStats.dpsAverage.length;
+    const result = new Array(len).fill(0);
+    for (const p of chartablePlayers) {
+      const arr = p.damageStats.dpsAverage;
+      for (let i = 0; i < Math.min(arr.length, len); i++) {
+        result[i] += arr[i];
+      }
+    }
+    return result;
+  });
+  let bossHpResampled = $derived.by(() => {
+    const len = aggregateDps.length;
+    if (len === 0 || bossHpLogs.length === 0) return [];
+    const primary = bossHpLogs.reduce((a, b) => (a[1].length >= b[1].length ? a : b));
+    const bossName = primary[0];
+    const log = primary[1];
+    if (log.length < 2) return [];
+    const max = Math.max(...log.slice(0, 5).map((e) => e.p));
+    const normalized = max > 1 ? log.map((e) => new BossHpLog(e.time, e.hp, e.p / max)) : log;
+    const resampled = resampleData(normalized, 5, len);
+    const totalBars = bossHpMap[bossName] ?? 0;
+    return resampled.map((e) => ({ bars: totalBars > 0 ? Math.round(e.p * totalBars) : 0, p: e.p }));
+  });
   let buffChartLegend = $derived(enc.parties.map((_, i) => "Party " + (i + 1)));
   let buffChartSeries = $derived(
     getSupportSynergiesOverTime(enc, encounter.fightStart, encounter.lastCombatPacket, 5000)
@@ -97,10 +131,26 @@
 
   $effect(() => {
     if (chartDiv) {
-      const { destroy } = chartable(chartDiv, chartOptions);
+      const { destroy, echartsInstance } = chartable(chartDiv, chartOptions);
       destroyChart = destroy;
+      echartsInst = echartsInstance;
     }
   });
+
+  function commitTimeWindow(w: { startSec: number; endSec: number } | null) {
+    timeWindow = w ? { startMs: w.startSec * 1000, endMs: w.endSec * 1000 } : null;
+    applyWindowToCharts(w?.startSec ?? 0, w?.endSec ?? encounter.duration / 1000);
+  }
+
+  function applyWindowToCharts(startSec: number, endSec: number) {
+    const durSec = encounter.duration / 1000;
+    if (durSec <= 0) return;
+    echartsInst?.dispatchAction({
+      type: "dataZoom",
+      start: (startSec / durSec) * 100,
+      end: (endSec / durSec) * 100
+    });
+  }
 
   onDestroy(() => {
     if (destroyChart) destroyChart();
@@ -232,7 +282,7 @@
 <div class="overflow-hidden text-neutral-100" oncontextmenu={handleRightClick}>
   <Card bind:self={screenshotDiv}>
     <!-- Enocunter summary -->
-    <LogEncounterInfo {enc} />
+    <LogEncounterInfo {enc} durationSec={Math.floor(encounter.duration / 1000)} dpsData={aggregateDps} bossHpData={bossHpResampled} oncommit={commitTimeWindow} />
 
     <!-- Content and tabs -->
     <div class="flex flex-col gap-2 py-2">

--- a/src/routes/(app)/logs/[id]/LogEncounterInfo.svelte
+++ b/src/routes/(app)/logs/[id]/LogEncounterInfo.svelte
@@ -5,8 +5,21 @@
   import { abbreviateNumber, timestampToMinutesAndSeconds } from "$lib/utils";
   import { middot } from "$lib/components/Snippets.svelte";
   import QuickTooltip from "$lib/components/QuickTooltip.svelte";
+  import TimeWindowSlider from "$lib/components/TimeWindowSlider.svelte";
 
-  let { enc }: { enc: EncounterState } = $props();
+  let {
+    enc,
+    durationSec,
+    dpsData,
+    bossHpData,
+    oncommit
+  }: {
+    enc: EncounterState;
+    durationSec: number;
+    dpsData: number[];
+    bossHpData: { bars: number; p: number }[];
+    oncommit: (w: { startSec: number; endSec: number } | null) => void;
+  } = $props();
 
   let locale: string | undefined = $state();
 
@@ -21,6 +34,7 @@
 </script>
 
 <div class="bg-black/10 px-3 py-2 text-sm" class:hidden={screenshot.state} id="header">
+  <TimeWindowSlider {durationSec} {dpsData} {bossHpData} {oncommit} class="-mx-3 mb-1" />
   <div class="flex flex-row gap-1">
     <div class="flex items-baseline gap-1 text-neutral-300">
       <div>Duration:</div>

--- a/src/routes/(app)/logs/[id]/LogSkillDetails.svelte
+++ b/src/routes/(app)/logs/[id]/LogSkillDetails.svelte
@@ -52,7 +52,7 @@
         acc.identity += buffs.identity;
         return acc;
       },
-      { buff: 0, brand: 0, identity: 0 }
+      { buff: 0, brand: 0, identity: 0, hat: 0 }
     );
   });
 


### PR DESCRIPTION
This came out of a request from a guildmate who wanted to look at specific stagger checks in TFM pulls, but with several checks it was difficult to determine what stagger contribution came from which check.  This just adds a general ability to select a data window and filter the various charts to that window.

Will keep the same window if you click into a player within a zoomed overview.

<img width="1253" height="639" alt="image" src="https://github.com/user-attachments/assets/0ffa9a22-b02c-400b-9e6c-beaf94df12ae" />

Current limitations:

The slider windows all data that's available in skillCastLog hit records — this covers the Damage tab (player/skill breakdown with all column values), Party Buffs, and Self Buffs. The following tabs use data aggregated by meter-core with no per-event timestamps and cannot be windowed by the frontend:

Shields tab — shieldsGivenBy/shieldsReceivedBy are pre-aggregated totals per buff ID with no temporal data
Tanked tab — damageTaken is a per-entity total from meter-core
Bosses tab — boss entity damage is aggregated by meter-core
Windowing these would require meter-core to expose timestamped shield/damage-taken events, similar to how skillCastLog provides per-hit data for damage.

Note - as with my previous PR this one is generated via claude primarily as these are not languages I am familiar with.  I am just interested in contributing where I can!