### PR TITLE
Add opt-in read-only localhost API

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ hashbrown = { version = "0.16.0", features = ["serde"] }
 r2d2_sqlite = "0.31.0"
 r2d2 = "0.8.10"
 rusqlite = { version = "0.37.0", features = ["bundled", "serde_json"] }
-tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "macros", "process", "net", "sync"] }
+tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "macros", "process", "net", "sync", "time"] }
 axum = "0.8"
 serde_with = "3.12.0"
 log = "0.4.18"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ hashbrown = { version = "0.16.0", features = ["serde"] }
 r2d2_sqlite = "0.31.0"
 r2d2 = "0.8.10"
 rusqlite = { version = "0.37.0", features = ["bundled", "serde_json"] }
-tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "macros", "process", "net", "sync", "time"] }
+tokio = { version = "1.48.0", features = ["rt", "macros", "process", "net", "sync", "time"] }
 axum = "0.8"
 serde_with = "3.12.0"
 log = "0.4.18"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,8 @@ hashbrown = { version = "0.16.0", features = ["serde"] }
 r2d2_sqlite = "0.31.0"
 r2d2 = "0.8.10"
 rusqlite = { version = "0.37.0", features = ["bundled", "serde_json"] }
-tokio = { version = "1.48.0", features = ["rt", "macros", "process"] }
+tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "macros", "process", "net", "sync"] }
+axum = "0.8"
 serde_with = "3.12.0"
 log = "0.4.18"
 flexi_logger = { version = "0.31.7", default-features = false }

--- a/src-tauri/src/database/models.rs
+++ b/src-tauri/src/database/models.rs
@@ -16,6 +16,28 @@ pub struct GetEncounterPreviewArgs {
     pub filter: SearchFilter,
 }
 
+/// Sanitized cleared-encounter summary exposed by the read-only local API.
+/// Intentionally contains no damage, player breakdowns, or party details.
+#[derive(Debug, Clone)]
+pub struct MeterClear {
+    pub id: i64,
+    pub boss: String,
+    pub difficulty: Option<String>,
+    pub fight_start_ms: i64,
+    pub duration_ms: i64,
+    pub local_player: Option<String>,
+    pub upload_id: Option<String>,
+}
+
+/// Latest class/ilvl metadata the meter knows for a local character.
+#[derive(Debug, Clone)]
+pub struct MeterCharacter {
+    pub name: String,
+    pub class_id: i32,
+    pub class: Option<String>,
+    pub gear_score: f32,
+}
+
 #[derive(Debug, Clone)]
 pub struct InsertEncounterArgs {
     pub encounter: Encounter,

--- a/src-tauri/src/database/models.rs
+++ b/src-tauri/src/database/models.rs
@@ -16,8 +16,6 @@ pub struct GetEncounterPreviewArgs {
     pub filter: SearchFilter,
 }
 
-/// Sanitized cleared-encounter summary exposed by the read-only local API.
-/// Intentionally contains no damage, player breakdowns, or party details.
 #[derive(Debug, Clone)]
 pub struct MeterClear {
     pub id: i64,
@@ -29,7 +27,6 @@ pub struct MeterClear {
     pub upload_id: Option<String>,
 }
 
-/// Latest class/ilvl metadata the meter knows for a local character.
 #[derive(Debug, Clone)]
 pub struct MeterCharacter {
     pub name: String,

--- a/src-tauri/src/database/queries.rs
+++ b/src-tauri/src/database/queries.rs
@@ -67,6 +67,39 @@ WHERE le.gear_score > 0
 GROUP BY e.local_player
 ORDER BY max_gs DESC";
 
+/// Read-only: cleared encounters within a time window, joined to their upstream
+/// (lostark.bible) upload id if one exists. Used by the local HTTP API.
+pub const SELECT_CLEARED_ENCOUNTERS_IN_RANGE: &str = r"
+SELECT
+    e.id,
+    e.current_boss,
+    e.difficulty,
+    e.fight_start,
+    e.duration,
+    e.local_player,
+    s.upstream_id
+FROM encounter_preview e
+LEFT JOIN sync_logs s ON s.encounter_id = e.id AND s.failed = 0
+WHERE e.cleared = 1
+  AND e.fight_start >= ?1
+  AND e.fight_start <= ?2
+ORDER BY e.fight_start ASC";
+
+/// Read-only: latest class/ilvl per local character. SQLite returns the bare
+/// columns (class_id, class) from the row holding MAX(gear_score).
+pub const SELECT_METER_CHARACTERS: &str = r"
+SELECT
+    e.local_player,
+    le.class_id,
+    le.class,
+    MAX(le.gear_score) AS max_gs
+FROM encounter_preview e
+JOIN entity le ON le.encounter_id = e.id AND le.name = e.local_player
+WHERE le.gear_score > 0
+  AND e.local_player IS NOT NULL
+GROUP BY e.local_player
+ORDER BY max_gs DESC";
+
 pub const INSERT_ENCOUNTER: &str = r"
 INSERT INTO encounter
 (

--- a/src-tauri/src/database/queries.rs
+++ b/src-tauri/src/database/queries.rs
@@ -74,16 +74,18 @@ SELECT
     e.id,
     e.current_boss,
     e.difficulty,
-    e.fight_start,
+    json_extract(en.misc, '$.ntpFightStart') AS ntp_fight_start,
     e.duration,
     e.local_player,
     s.upstream_id
 FROM encounter_preview e
+JOIN encounter en ON en.id = e.id
 LEFT JOIN sync_logs s ON s.encounter_id = e.id AND s.failed = 0
 WHERE e.cleared = 1
-  AND e.fight_start >= ?1
-  AND e.fight_start <= ?2
-ORDER BY e.fight_start ASC";
+  AND json_extract(en.misc, '$.ntpFightStart') IS NOT NULL
+  AND json_extract(en.misc, '$.ntpFightStart') >= ?1
+  AND json_extract(en.misc, '$.ntpFightStart') <= ?2
+ORDER BY ntp_fight_start ASC";
 
 /// Read-only: latest class/ilvl per local character. SQLite returns the bare
 /// columns (class_id, class) from the row holding MAX(gear_score).

--- a/src-tauri/src/database/queries.rs
+++ b/src-tauri/src/database/queries.rs
@@ -67,8 +67,6 @@ WHERE le.gear_score > 0
 GROUP BY e.local_player
 ORDER BY max_gs DESC";
 
-/// Read-only: cleared encounters within a time window, joined to their upstream
-/// (lostark.bible) upload id if one exists. Used by the local HTTP API.
 pub const SELECT_CLEARED_ENCOUNTERS_IN_RANGE: &str = r"
 SELECT
     e.id,
@@ -87,8 +85,6 @@ WHERE e.cleared = 1
   AND json_extract(en.misc, '$.ntpFightStart') <= ?2
 ORDER BY ntp_fight_start ASC";
 
-/// Read-only: latest class/ilvl per local character. SQLite returns the bare
-/// columns (class_id, class) from the row holding MAX(gear_score).
 pub const SELECT_METER_CHARACTERS: &str = r"
 SELECT
     e.local_player,

--- a/src-tauri/src/database/repository.rs
+++ b/src-tauri/src/database/repository.rs
@@ -174,6 +174,58 @@ impl Repository {
         Ok(characters)
     }
 
+    /// Read-only: sanitized cleared-encounter summaries within a time window for
+    /// the local HTTP API. Contains no damage/player/party data.
+    pub fn get_cleared_encounters_in_range(
+        &self,
+        since_ms: i64,
+        until_ms: i64,
+    ) -> Result<Vec<MeterClear>> {
+        let connection = self.0.get()?;
+        let mut statement = connection.prepare_cached(SELECT_CLEARED_ENCOUNTERS_IN_RANGE)?;
+
+        let rows = statement.query_map(params![since_ms, until_ms], |row| {
+            Result::Ok(MeterClear {
+                id: row.get(0)?,
+                boss: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                difficulty: row.get(2)?,
+                fight_start_ms: row.get::<_, Option<i64>>(3)?.unwrap_or(0),
+                duration_ms: row.get::<_, Option<i64>>(4)?.unwrap_or(0),
+                local_player: row.get(5)?,
+                upload_id: row.get(6)?,
+            })
+        })?;
+
+        let clears = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(clears)
+    }
+
+    /// Read-only: latest class/ilvl metadata per local character. When `names` is
+    /// non-empty, only those names (case-insensitive) are returned.
+    pub fn get_meter_characters(&self, names: &[String]) -> Result<Vec<MeterCharacter>> {
+        let connection = self.0.get()?;
+        let mut statement = connection.prepare_cached(SELECT_METER_CHARACTERS)?;
+
+        let rows = statement.query_map([], |row| {
+            Result::Ok(MeterCharacter {
+                name: row.get::<_, Option<String>>(0)?.unwrap_or_default(),
+                class_id: row.get::<_, Option<i32>>(1)?.unwrap_or(0),
+                class: row.get(2)?,
+                gear_score: row.get::<_, Option<f32>>(3)?.unwrap_or(0.0),
+            })
+        })?;
+
+        let mut characters = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+
+        if !names.is_empty() {
+            let wanted: std::collections::HashSet<String> =
+                names.iter().map(|n| n.to_lowercase()).collect();
+            characters.retain(|c| wanted.contains(&c.name.to_lowercase()));
+        }
+
+        Ok(characters)
+    }
+
     pub fn delete_all_uncleared_encounters(&self, keep_favorites: bool) -> Result<()> {
         let connection = self.0.get()?;
 

--- a/src-tauri/src/database/repository.rs
+++ b/src-tauri/src/database/repository.rs
@@ -174,8 +174,6 @@ impl Repository {
         Ok(characters)
     }
 
-    /// Read-only: sanitized cleared-encounter summaries within a time window for
-    /// the local HTTP API. Contains no damage/player/party data.
     pub fn get_cleared_encounters_in_range(
         &self,
         since_ms: i64,
@@ -200,8 +198,6 @@ impl Repository {
         Ok(clears)
     }
 
-    /// Read-only: latest class/ilvl metadata per local character. When `names` is
-    /// non-empty, only those names (case-insensitive) are returned.
     pub fn get_meter_characters(&self, names: &[String]) -> Result<Vec<MeterCharacter>> {
         let connection = self.0.get()?;
         let mut statement = connection.prepare_cached(SELECT_METER_CHARACTERS)?;

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -10,6 +10,7 @@ use crate::app::autostart::{AutoLaunch, AutoLaunchManager};
 use crate::constants::*;
 use crate::database::models::{GetEncounterPreviewArgs, InsertSyncLogsArgs};
 use crate::database::{Database, Repository};
+use crate::local_api::{LocalApiManager, LocalApiStatus};
 use crate::models::*;
 use crate::settings::{Settings, SettingsManager};
 use crate::shell::ShellManager;
@@ -59,6 +60,7 @@ pub fn generate_handlers() -> Box<dyn Fn(Invoke) -> bool + Send + Sync> {
         install_beta_update,
         install_stable_update,
         get_local_characters,
+        get_local_api_status,
     ])
 }
 
@@ -222,12 +224,24 @@ pub fn open_url(app_handle: AppHandle, url: String) {
 }
 
 #[command]
-pub fn save_settings(settings_manager: State<SettingsManager>, settings: Settings) -> Result<()> {
+pub fn save_settings(
+    settings_manager: State<SettingsManager>,
+    local_api: State<LocalApiManager>,
+    settings: Settings,
+) -> Result<()> {
     settings_manager
         .save(&settings)
         .context("could not write to settings file")?;
 
+    // Apply any local API changes (start/stop/restart) immediately.
+    local_api.reconcile(Some(&settings));
+
     Ok(())
+}
+
+#[command]
+pub fn get_local_api_status(local_api: State<LocalApiManager>) -> LocalApiStatus {
+    local_api.status()
 }
 
 #[command]

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -61,6 +61,7 @@ pub fn generate_handlers() -> Box<dyn Fn(Invoke) -> bool + Send + Sync> {
         install_stable_update,
         get_local_characters,
         get_local_api_status,
+        restart_local_api,
     ])
 }
 
@@ -224,23 +225,29 @@ pub fn open_url(app_handle: AppHandle, url: String) {
 }
 
 #[command]
-pub fn save_settings(
-    settings_manager: State<SettingsManager>,
-    local_api: State<LocalApiManager>,
-    settings: Settings,
-) -> Result<()> {
+pub fn save_settings(settings_manager: State<SettingsManager>, settings: Settings) -> Result<()> {
     settings_manager
         .save(&settings)
         .context("could not write to settings file")?;
-
-    // Apply any local API changes (start/stop/restart) immediately.
-    local_api.reconcile(Some(&settings));
 
     Ok(())
 }
 
 #[command]
 pub fn get_local_api_status(local_api: State<LocalApiManager>) -> LocalApiStatus {
+    local_api.status()
+}
+
+/// Start/stop/restart the local API on demand — bound to the Apply/Restart
+/// button so saving unrelated settings (or other windows syncing settings)
+/// never thrashes the listener. Reads the just-persisted settings.
+#[command]
+pub fn restart_local_api(
+    settings_manager: State<SettingsManager>,
+    local_api: State<LocalApiManager>,
+) -> LocalApiStatus {
+    let settings = settings_manager.read().ok().flatten();
+    local_api.reconcile(settings.as_ref());
     local_api.status()
 }
 

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -238,9 +238,6 @@ pub fn get_local_api_status(local_api: State<LocalApiManager>) -> LocalApiStatus
     local_api.status()
 }
 
-/// Start/stop/restart the local API on demand — bound to the Apply/Restart
-/// button so saving unrelated settings (or other windows syncing settings)
-/// never thrashes the listener. Reads the just-persisted settings.
 #[command]
 pub fn restart_local_api(
     settings_manager: State<SettingsManager>,

--- a/src-tauri/src/local_api.rs
+++ b/src-tauri/src/local_api.rs
@@ -1,0 +1,483 @@
+//! Read-only local HTTP API.
+//!
+//! Lets a browser running on an allow-listed origin (e.g. neria.dev) read
+//! *sanitized* meter clears from this machine so private logs can still be
+//! detected by external trackers. Security model:
+//!
+//! - Bound to `127.0.0.1` only, disabled by default.
+//! - Every data endpoint requires `Authorization: Bearer <token>`.
+//! - No cookies/credentials are ever used or reflected.
+//! - CORS `Access-Control-Allow-Origin` is reflected *only* for exact matches
+//!   in the configured allowlist (never `*`), and Chromium Private Network
+//!   Access preflights are answered only for those origins.
+//! - Responses are `Cache-Control: no-store`.
+//!
+//! No combat logs, damage, player breakdowns, skill/buff logs or party details
+//! are ever exposed.
+
+use std::sync::{Arc, Mutex};
+
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::{Query, Request, State},
+    http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, header},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use chrono::Utc;
+use log::{error, info};
+use serde::{Deserialize, Serialize};
+use tauri::async_runtime::JoinHandle;
+use tokio::sync::oneshot;
+
+use crate::database::Repository;
+use crate::settings::{LocalApiSettings, Settings};
+
+const SCHEMA_VERSION: u32 = 1;
+
+/// Manages the lifecycle of the local API server. Managed as Tauri state so it
+/// can be reconciled whenever settings are saved.
+pub struct LocalApiManager {
+    repository: Arc<Repository>,
+    version: String,
+    inner: Mutex<Option<RunningServer>>,
+    last_error: Mutex<Option<String>>,
+}
+
+struct RunningServer {
+    port: u16,
+    token: String,
+    allowed_origins: Vec<String>,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: JoinHandle<()>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalApiStatus {
+    pub running: bool,
+    pub port: Option<u16>,
+    pub error: Option<String>,
+}
+
+impl LocalApiManager {
+    pub fn new(repository: Arc<Repository>, version: String) -> Self {
+        Self {
+            repository,
+            version,
+            inner: Mutex::new(None),
+            last_error: Mutex::new(None),
+        }
+    }
+
+    pub fn status(&self) -> LocalApiStatus {
+        let running = self.inner.lock().unwrap();
+        LocalApiStatus {
+            running: running.is_some(),
+            port: running.as_ref().map(|s| s.port),
+            error: self.last_error.lock().unwrap().clone(),
+        }
+    }
+
+    fn set_error(&self, error: Option<String>) {
+        *self.last_error.lock().unwrap() = error;
+    }
+
+    /// Start, stop, or restart the server to match the given settings. Safe to
+    /// call repeatedly; it only restarts when the relevant config changed.
+    pub fn reconcile(&self, settings: Option<&Settings>) {
+        let cfg = settings
+            .map(|s| s.local_api.clone())
+            .unwrap_or_default();
+
+        let should_run = cfg.enabled && !cfg.token.is_empty() && cfg.port > 0;
+
+        let mut guard = self.inner.lock().unwrap();
+
+        // Already running with identical config: nothing to do.
+        let unchanged = match guard.as_ref() {
+            Some(r) => {
+                should_run
+                    && r.port == cfg.port
+                    && r.token == cfg.token
+                    && r.allowed_origins == cfg.allowed_origins
+            }
+            None => false,
+        };
+        if unchanged {
+            return;
+        }
+
+        // Stop any existing server (config changed, or we're disabling).
+        if let Some(mut server) = guard.take() {
+            if let Some(tx) = server.shutdown.take() {
+                let _ = tx.send(());
+            }
+            server.handle.abort();
+            info!("local api stopped");
+        }
+
+        if !should_run {
+            if cfg.enabled && cfg.token.is_empty() {
+                self.set_error(Some("no token configured".to_string()));
+            } else {
+                self.set_error(None);
+            }
+            return;
+        }
+
+        match self.start(&cfg) {
+            Ok(server) => {
+                *guard = Some(server);
+                self.set_error(None);
+            }
+            Err(e) => {
+                error!("failed to start local api: {e}");
+                self.set_error(Some(e.to_string()));
+            }
+        }
+    }
+
+    fn start(&self, cfg: &LocalApiSettings) -> anyhow::Result<RunningServer> {
+        // Bind synchronously so port-in-use errors surface immediately.
+        let std_listener = std::net::TcpListener::bind(("127.0.0.1", cfg.port))?;
+        std_listener.set_nonblocking(true)?;
+
+        let state = ApiState {
+            repository: self.repository.clone(),
+            version: self.version.clone(),
+            token: Arc::new(cfg.token.clone()),
+            allowed_origins: Arc::new(cfg.allowed_origins.clone()),
+        };
+
+        let (tx, rx) = oneshot::channel::<()>();
+        let port = cfg.port;
+
+        let handle = tauri::async_runtime::spawn(async move {
+            let listener = match tokio::net::TcpListener::from_std(std_listener) {
+                Ok(l) => l,
+                Err(e) => {
+                    error!("local api listener error: {e}");
+                    return;
+                }
+            };
+            let app = build_router(state);
+            let server = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = rx.await;
+                });
+            if let Err(e) = server.await {
+                error!("local api server error: {e}");
+            }
+        });
+
+        info!("local api listening on 127.0.0.1:{port}");
+
+        Ok(RunningServer {
+            port,
+            token: cfg.token.clone(),
+            allowed_origins: cfg.allowed_origins.clone(),
+            shutdown: Some(tx),
+            handle,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct ApiState {
+    repository: Arc<Repository>,
+    version: String,
+    token: Arc<String>,
+    allowed_origins: Arc<Vec<String>>,
+}
+
+fn build_router(state: ApiState) -> Router {
+    Router::new()
+        .route("/v1/status", get(status_handler))
+        .route("/v1/encounters", get(encounters_handler))
+        .route("/v1/characters", get(characters_handler))
+        .fallback(fallback_handler)
+        .layer(middleware::from_fn_with_state(state.clone(), cors_middleware))
+        .with_state(state)
+}
+
+// ---------------------------------------------------------------------------
+// Responses / requests
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusResponse {
+    ok: bool,
+    app: &'static str,
+    version: String,
+    schema_version: u32,
+    server_time_ms: i64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EncountersResponse {
+    schema_version: u32,
+    encounters: Vec<ApiEncounter>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApiEncounter {
+    source_id: String,
+    boss: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    difficulty: Option<String>,
+    fight_start_ms: i64,
+    duration_ms: i64,
+    cleared: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_player: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    upload_id: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CharactersResponse {
+    schema_version: u32,
+    characters: Vec<ApiCharacter>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApiCharacter {
+    name: String,
+    class_id: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    class: Option<String>,
+    gear_score: f32,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EncountersQuery {
+    since_ms: Option<i64>,
+    until_ms: Option<i64>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CharactersQuery {
+    names: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn status_handler(State(state): State<ApiState>, headers: HeaderMap) -> Response {
+    if let Err(e) = check_auth(&headers, &state.token) {
+        return e;
+    }
+    Json(StatusResponse {
+        ok: true,
+        app: "loa-logs",
+        version: state.version.clone(),
+        schema_version: SCHEMA_VERSION,
+        server_time_ms: now_ms(),
+    })
+    .into_response()
+}
+
+async fn encounters_handler(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    Query(q): Query<EncountersQuery>,
+) -> Response {
+    if let Err(e) = check_auth(&headers, &state.token) {
+        return e;
+    }
+
+    let until = q.until_ms.unwrap_or_else(now_ms);
+    let since = q.since_ms.unwrap_or(0);
+
+    match state.repository.get_cleared_encounters_in_range(since, until) {
+        Ok(clears) => {
+            let encounters = clears
+                .into_iter()
+                .map(|c| ApiEncounter {
+                    source_id: c.id.to_string(),
+                    boss: c.boss,
+                    difficulty: c.difficulty,
+                    fight_start_ms: c.fight_start_ms,
+                    duration_ms: c.duration_ms,
+                    cleared: true,
+                    local_player: c.local_player,
+                    upload_id: c.upload_id,
+                })
+                .collect();
+            Json(EncountersResponse {
+                schema_version: SCHEMA_VERSION,
+                encounters,
+            })
+            .into_response()
+        }
+        Err(e) => {
+            error!("local api encounters query failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+async fn characters_handler(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    Query(q): Query<CharactersQuery>,
+) -> Response {
+    if let Err(e) = check_auth(&headers, &state.token) {
+        return e;
+    }
+
+    let names: Vec<String> = q
+        .names
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    match state.repository.get_meter_characters(&names) {
+        Ok(rows) => {
+            let characters = rows
+                .into_iter()
+                .map(|c| ApiCharacter {
+                    name: c.name,
+                    class_id: c.class_id,
+                    class: c.class,
+                    gear_score: c.gear_score,
+                })
+                .collect();
+            Json(CharactersResponse {
+                schema_version: SCHEMA_VERSION,
+                characters,
+            })
+            .into_response()
+        }
+        Err(e) => {
+            error!("local api characters query failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+async fn fallback_handler() -> Response {
+    StatusCode::NOT_FOUND.into_response()
+}
+
+// ---------------------------------------------------------------------------
+// CORS / Private Network Access + auth
+// ---------------------------------------------------------------------------
+
+async fn cors_middleware(State(state): State<ApiState>, req: Request, next: Next) -> Response {
+    let origin = req
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let allowed = origin
+        .as_deref()
+        .map(|o| is_origin_allowed(&state.allowed_origins, o))
+        .unwrap_or(false);
+
+    if req.method() == Method::OPTIONS {
+        // Preflight: never requires auth.
+        if !allowed {
+            return StatusCode::FORBIDDEN.into_response();
+        }
+        let pna_requested = req
+            .headers()
+            .get("access-control-request-private-network")
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        let mut resp = Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(Body::empty())
+            .unwrap();
+        let h = resp.headers_mut();
+        set_origin(h, origin.as_deref());
+        insert_static(h, header::ACCESS_CONTROL_ALLOW_METHODS, "GET, OPTIONS");
+        insert_static(
+            h,
+            header::ACCESS_CONTROL_ALLOW_HEADERS,
+            "Authorization, Content-Type",
+        );
+        if pna_requested {
+            insert_static(
+                h,
+                HeaderName::from_static("access-control-allow-private-network"),
+                "true",
+            );
+        }
+        insert_static(
+            h,
+            header::VARY,
+            "Origin, Access-Control-Request-Private-Network",
+        );
+        return resp;
+    }
+
+    let mut resp = next.run(req).await;
+    let h = resp.headers_mut();
+    if allowed {
+        set_origin(h, origin.as_deref());
+        insert_static(h, header::VARY, "Origin");
+    }
+    insert_static(h, header::CACHE_CONTROL, "no-store");
+    resp
+}
+
+fn is_origin_allowed(allowed: &[String], origin: &str) -> bool {
+    allowed.iter().any(|o| o == origin)
+}
+
+fn set_origin(headers: &mut HeaderMap, origin: Option<&str>) {
+    if let Some(o) = origin {
+        if let Ok(value) = HeaderValue::from_str(o) {
+            headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, value);
+        }
+    }
+}
+
+fn insert_static(headers: &mut HeaderMap, name: HeaderName, value: &'static str) {
+    headers.insert(name, HeaderValue::from_static(value));
+}
+
+fn check_auth(headers: &HeaderMap, token: &str) -> Result<(), Response> {
+    let provided = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("");
+
+    if !token.is_empty() && constant_time_eq(provided.as_bytes(), token.as_bytes()) {
+        Ok(())
+    } else {
+        Err(StatusCode::UNAUTHORIZED.into_response())
+    }
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+fn now_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}

--- a/src-tauri/src/local_api.rs
+++ b/src-tauri/src/local_api.rs
@@ -38,20 +38,25 @@ use crate::settings::{LocalApiSettings, Settings};
 const SCHEMA_VERSION: u32 = 1;
 
 /// Manages the lifecycle of the local API server. Managed as Tauri state so it
-/// can be reconciled whenever settings are saved.
+/// can be reconciled at app launch and from the Apply/Restart button.
 pub struct LocalApiManager {
     repository: Arc<Repository>,
     version: String,
     inner: Mutex<Option<RunningServer>>,
-    last_error: Mutex<Option<String>>,
+    status: Arc<Mutex<RuntimeState>>,
 }
 
 struct RunningServer {
-    port: u16,
-    token: String,
-    allowed_origins: Vec<String>,
+    cfg: LocalApiSettings,
     shutdown: Option<oneshot::Sender<()>>,
     handle: JoinHandle<()>,
+}
+
+#[derive(Default)]
+struct RuntimeState {
+    running: bool,
+    port: Option<u16>,
+    error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -68,41 +73,51 @@ impl LocalApiManager {
             repository,
             version,
             inner: Mutex::new(None),
-            last_error: Mutex::new(None),
+            status: Arc::new(Mutex::new(RuntimeState::default())),
         }
     }
 
     pub fn status(&self) -> LocalApiStatus {
-        let running = self.inner.lock().unwrap();
+        let st = self.status.lock().unwrap();
         LocalApiStatus {
-            running: running.is_some(),
-            port: running.as_ref().map(|s| s.port),
-            error: self.last_error.lock().unwrap().clone(),
+            running: st.running,
+            port: st.port,
+            error: st.error.clone(),
         }
     }
 
-    fn set_error(&self, error: Option<String>) {
-        *self.last_error.lock().unwrap() = error;
+    /// Stop the server (if any). Called on app exit so the port is released
+    /// promptly on a clean shutdown.
+    pub fn shutdown(&self) {
+        let mut guard = self.inner.lock().unwrap();
+        if let Some(mut server) = guard.take() {
+            if let Some(tx) = server.shutdown.take() {
+                let _ = tx.send(());
+            }
+            server.handle.abort();
+        }
+        let mut st = self.status.lock().unwrap();
+        st.running = false;
+        st.port = None;
     }
 
-    /// Start, stop, or restart the server to match the given settings. Safe to
-    /// call repeatedly; it only restarts when the relevant config changed.
+    /// Start, stop, or restart the server to match the given settings. Never
+    /// blocks the caller: binding (and any rebind retry) happens on the async
+    /// runtime, so calling this from a UI/command thread can't freeze the app.
+    /// Idempotent — only restarts when the relevant config changed.
     pub fn reconcile(&self, settings: Option<&Settings>) {
-        let cfg = settings
-            .map(|s| s.local_api.clone())
-            .unwrap_or_default();
-
+        let cfg = settings.map(|s| s.local_api.clone()).unwrap_or_default();
         let should_run = cfg.enabled && !cfg.token.is_empty() && cfg.port > 0;
 
         let mut guard = self.inner.lock().unwrap();
 
         // Already running with identical config: nothing to do.
         let unchanged = match guard.as_ref() {
-            Some(r) => {
+            Some(s) => {
                 should_run
-                    && r.port == cfg.port
-                    && r.token == cfg.token
-                    && r.allowed_origins == cfg.allowed_origins
+                    && s.cfg.port == cfg.port
+                    && s.cfg.token == cfg.token
+                    && s.cfg.allowed_origins == cfg.allowed_origins
             }
             None => false,
         };
@@ -116,72 +131,77 @@ impl LocalApiManager {
                 let _ = tx.send(());
             }
             server.handle.abort();
-            info!("local api stopped");
+        }
+
+        {
+            let mut st = self.status.lock().unwrap();
+            st.running = false;
+            st.port = None;
+            st.error = if cfg.enabled && cfg.token.is_empty() {
+                Some("no token configured".to_string())
+            } else {
+                None
+            };
         }
 
         if !should_run {
-            if cfg.enabled && cfg.token.is_empty() {
-                self.set_error(Some("no token configured".to_string()));
-            } else {
-                self.set_error(None);
-            }
             return;
         }
 
-        match self.start(&cfg) {
-            Ok(server) => {
-                *guard = Some(server);
-                self.set_error(None);
-            }
-            Err(e) => {
-                error!("failed to start local api: {e}");
-                self.set_error(Some(e.to_string()));
-            }
-        }
+        *guard = Some(self.spawn(&cfg));
     }
 
-    fn start(&self, cfg: &LocalApiSettings) -> anyhow::Result<RunningServer> {
-        // Bind synchronously so port-in-use errors surface immediately.
-        let std_listener = std::net::TcpListener::bind(("127.0.0.1", cfg.port))?;
-        std_listener.set_nonblocking(true)?;
-
+    fn spawn(&self, cfg: &LocalApiSettings) -> RunningServer {
         let state = ApiState {
             repository: self.repository.clone(),
             version: self.version.clone(),
             token: Arc::new(cfg.token.clone()),
             allowed_origins: Arc::new(cfg.allowed_origins.clone()),
         };
-
+        let status = self.status.clone();
         let (tx, rx) = oneshot::channel::<()>();
         let port = cfg.port;
 
         let handle = tauri::async_runtime::spawn(async move {
-            let listener = match tokio::net::TcpListener::from_std(std_listener) {
+            let listener = match bind_with_retry(port).await {
                 Ok(l) => l,
                 Err(e) => {
-                    error!("local api listener error: {e}");
+                    error!("local api failed to bind 127.0.0.1:{port}: {e}");
+                    let mut st = status.lock().unwrap();
+                    st.running = false;
+                    st.port = None;
+                    st.error = Some(format!("could not bind port {port} ({e})"));
                     return;
                 }
             };
+
+            {
+                let mut st = status.lock().unwrap();
+                st.running = true;
+                st.port = Some(port);
+                st.error = None;
+            }
+            info!("local api listening on 127.0.0.1:{port}");
+
             let app = build_router(state);
-            let server = axum::serve(listener, app)
-                .with_graceful_shutdown(async move {
-                    let _ = rx.await;
-                });
+            let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+                let _ = rx.await;
+            });
             if let Err(e) = server.await {
                 error!("local api server error: {e}");
             }
+
+            info!("local api stopped");
+            let mut st = status.lock().unwrap();
+            st.running = false;
+            st.port = None;
         });
 
-        info!("local api listening on 127.0.0.1:{port}");
-
-        Ok(RunningServer {
-            port,
-            token: cfg.token.clone(),
-            allowed_origins: cfg.allowed_origins.clone(),
+        RunningServer {
+            cfg: cfg.clone(),
             shutdown: Some(tx),
             handle,
-        })
+        }
     }
 }
 
@@ -480,4 +500,22 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 
 fn now_ms() -> i64 {
     Utc::now().timestamp_millis()
+}
+
+/// Bind 127.0.0.1:port on the async runtime, retrying briefly so an in-place
+/// restart doesn't fail while the previous listener is still being torn down.
+async fn bind_with_retry(port: u16) -> std::io::Result<tokio::net::TcpListener> {
+    let mut last_err: Option<std::io::Error> = None;
+    for attempt in 0..10 {
+        match tokio::net::TcpListener::bind(("127.0.0.1", port)).await {
+            Ok(listener) => return Ok(listener),
+            Err(e) => {
+                last_err = Some(e);
+                if attempt < 9 {
+                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                }
+            }
+        }
+    }
+    Err(last_err.expect("bind loop ran at least once"))
 }

--- a/src-tauri/src/local_api/mod.rs
+++ b/src-tauri/src/local_api/mod.rs
@@ -1,19 +1,4 @@
-//! Read-only local HTTP API.
-//!
-//! Lets a browser running on an allow-listed origin (e.g. neria.dev) read
-//! *sanitized* meter clears from this machine so private logs can still be
-//! detected by external trackers. Security model:
-//!
-//! - Bound to `127.0.0.1` only, disabled by default.
-//! - Every data endpoint requires `Authorization: Bearer <token>`.
-//! - No cookies/credentials are ever used or reflected.
-//! - CORS `Access-Control-Allow-Origin` is reflected *only* for exact matches
-//!   in the configured allowlist (never `*`), and Chromium Private Network
-//!   Access preflights are answered only for those origins.
-//! - Responses are `Cache-Control: no-store`.
-//!
-//! No combat logs, damage, player breakdowns, skill/buff logs or party details
-//! are ever exposed.
+//! Read-only localhost API for external tools.
 
 use std::sync::{Arc, Mutex};
 
@@ -37,8 +22,6 @@ use crate::settings::{LocalApiSettings, Settings};
 
 const SCHEMA_VERSION: u32 = 1;
 
-/// Manages the lifecycle of the local API server. Managed as Tauri state so it
-/// can be reconciled at app launch and from the Apply/Restart button.
 pub struct LocalApiManager {
     repository: Arc<Repository>,
     version: String,
@@ -86,8 +69,6 @@ impl LocalApiManager {
         }
     }
 
-    /// Stop the server (if any). Called on app exit so the port is released
-    /// promptly on a clean shutdown.
     pub fn shutdown(&self) {
         let mut guard = self.inner.lock().unwrap();
         if let Some(mut server) = guard.take() {
@@ -101,20 +82,17 @@ impl LocalApiManager {
         st.port = None;
     }
 
-    /// Start, stop, or restart the server to match the given settings. Never
-    /// blocks the caller: binding (and any rebind retry) happens on the async
-    /// runtime, so calling this from a UI/command thread can't freeze the app.
-    /// Idempotent — only restarts when the relevant config changed.
     pub fn reconcile(&self, settings: Option<&Settings>) {
         let cfg = settings.map(|s| s.local_api.clone()).unwrap_or_default();
         let should_run = cfg.enabled && !cfg.token.is_empty() && cfg.port > 0;
 
         let mut guard = self.inner.lock().unwrap();
 
-        // Already running with identical config: nothing to do.
+        let running = self.status.lock().unwrap().running;
         let unchanged = match guard.as_ref() {
             Some(s) => {
                 should_run
+                    && running
                     && s.cfg.port == cfg.port
                     && s.cfg.token == cfg.token
                     && s.cfg.allowed_origins == cfg.allowed_origins
@@ -125,7 +103,6 @@ impl LocalApiManager {
             return;
         }
 
-        // Stop any existing server (config changed, or we're disabling).
         if let Some(mut server) = guard.take() {
             if let Some(tx) = server.shutdown.take() {
                 let _ = tx.send(());
@@ -223,10 +200,6 @@ fn build_router(state: ApiState) -> Router {
         .with_state(state)
 }
 
-// ---------------------------------------------------------------------------
-// Responses / requests
-// ---------------------------------------------------------------------------
-
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct StatusResponse {
@@ -289,10 +262,6 @@ struct EncountersQuery {
 struct CharactersQuery {
     names: Option<String>,
 }
-
-// ---------------------------------------------------------------------------
-// Handlers
-// ---------------------------------------------------------------------------
 
 async fn status_handler(State(state): State<ApiState>, headers: HeaderMap) -> Response {
     if let Err(e) = check_auth(&headers, &state.token) {
@@ -393,10 +362,6 @@ async fn fallback_handler() -> Response {
     StatusCode::NOT_FOUND.into_response()
 }
 
-// ---------------------------------------------------------------------------
-// CORS / Private Network Access + auth
-// ---------------------------------------------------------------------------
-
 async fn cors_middleware(State(state): State<ApiState>, req: Request, next: Next) -> Response {
     let origin = req
         .headers()
@@ -409,7 +374,6 @@ async fn cors_middleware(State(state): State<ApiState>, req: Request, next: Next
         .unwrap_or(false);
 
     if req.method() == Method::OPTIONS {
-        // Preflight: never requires auth.
         if !allowed {
             return StatusCode::FORBIDDEN.into_response();
         }
@@ -502,8 +466,6 @@ fn now_ms() -> i64 {
     Utc::now().timestamp_millis()
 }
 
-/// Bind 127.0.0.1:port on the async runtime, retrying briefly so an in-place
-/// restart doesn't fail while the previous listener is still being torn down.
 async fn bind_with_retry(port: u16) -> std::io::Result<tokio::net::TcpListener> {
     let mut last_err: Option<std::io::Error> = None;
     for attempt in 0..10 {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -35,6 +35,7 @@ use crate::setup::setup;
 use crate::ui::on_window_event;
 use anyhow::Result;
 use std::sync::Arc;
+use tauri::Manager;
 use tauri::async_runtime;
 use tokio::runtime::Handle;
 
@@ -85,8 +86,14 @@ async fn main() -> Result<()> {
         .setup(setup)
         .on_window_event(on_window_event)
         .invoke_handler(generate_handlers())
-        .run(tauri_context)
-        .expect("error while running application");
+        .build(tauri_context)
+        .expect("error while building application")
+        .run(|app_handle, event| {
+            // Release the local API port promptly on a clean exit.
+            if let tauri::RunEvent::Exit = event {
+                app_handle.state::<LocalApiManager>().shutdown();
+            }
+        });
 
     Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ mod handlers;
 #[cfg(feature = "meter-core")]
 mod live;
 mod local;
+mod local_api;
 mod misc;
 mod models;
 mod nineveh;
@@ -27,11 +28,13 @@ use crate::context::AppContext;
 use crate::data::AssetPreloader;
 use crate::database::Database;
 use crate::handlers::generate_handlers;
+use crate::local_api::LocalApiManager;
 use crate::misc::load_windivert;
 use crate::settings::SettingsManager;
 use crate::setup::setup;
 use crate::ui::on_window_event;
 use anyhow::Result;
+use std::sync::Arc;
 use tauri::async_runtime;
 use tokio::runtime::Handle;
 
@@ -52,6 +55,8 @@ async fn main() -> Result<()> {
     let database = Database::new(context.database_path.clone(), &context.version)
         .expect("error setting up database: {}");
     let repository = database.create_repository();
+    let local_api_manager =
+        LocalApiManager::new(Arc::new(database.create_repository()), context.version.clone());
     let auto_launch_manager = AutoLaunchManager::new(&package_info.name, &context.app_path);
 
     let handle = Handle::current();
@@ -63,6 +68,7 @@ async fn main() -> Result<()> {
         .manage(database)
         .manage(repository)
         .manage(settings_manager)
+        .manage(local_api_manager)
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -89,7 +89,6 @@ async fn main() -> Result<()> {
         .build(tauri_context)
         .expect("error while building application")
         .run(|app_handle, event| {
-            // Release the local API port promptly on a clean exit.
             if let tauri::RunEvent::Exit = event {
                 app_handle.state::<LocalApiManager>().shutdown();
             }

--- a/src-tauri/src/settings/model.rs
+++ b/src-tauri/src/settings/model.rs
@@ -5,8 +5,49 @@ use serde_json::{Map, Value};
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
     pub general: GeneralSettings,
+    #[serde(default)]
+    pub local_api: LocalApiSettings,
     #[serde(flatten)]
     pub extra: Map<String, Value>,
+}
+
+/// Settings for the read-only local HTTP API that lets a browser (e.g. neria.dev)
+/// read sanitized meter clears from this machine. Disabled by default and bound to
+/// 127.0.0.1 only. See `crate::local_api`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct LocalApiSettings {
+    pub enabled: bool,
+    pub port: u16,
+    pub token: String,
+    pub allowed_origins: Vec<String>,
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}
+
+impl Default for LocalApiSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            port: default_local_api_port(),
+            token: String::new(),
+            allowed_origins: default_allowed_origins(),
+            extra: Map::new(),
+        }
+    }
+}
+
+fn default_local_api_port() -> u16 {
+    6041
+}
+
+fn default_allowed_origins() -> Vec<String> {
+    vec![
+        "https://neria.dev".to_string(),
+        "https://dev-neria.niome.dev".to_string(),
+        "http://localhost:5173".to_string(),
+        "http://127.0.0.1:5173".to_string(),
+    ]
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src-tauri/src/settings/model.rs
+++ b/src-tauri/src/settings/model.rs
@@ -38,7 +38,7 @@ impl Default for LocalApiSettings {
 }
 
 fn default_local_api_port() -> u16 {
-    6041
+    16724
 }
 
 fn default_allowed_origins() -> Vec<String> {

--- a/src-tauri/src/settings/model.rs
+++ b/src-tauri/src/settings/model.rs
@@ -11,9 +11,6 @@ pub struct Settings {
     pub extra: Map<String, Value>,
 }
 
-/// Settings for the read-only local HTTP API that lets a browser (e.g. neria.dev)
-/// read sanitized meter clears from this machine. Disabled by default and bound to
-/// 127.0.0.1 only. See `crate::local_api`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct LocalApiSettings {
@@ -42,12 +39,7 @@ fn default_local_api_port() -> u16 {
 }
 
 fn default_allowed_origins() -> Vec<String> {
-    vec![
-        "https://neria.dev".to_string(),
-        "https://dev-neria.niome.dev".to_string(),
-        "http://localhost:5173".to_string(),
-        "http://127.0.0.1:5173".to_string(),
-    ]
+    vec![]
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -34,7 +34,6 @@ pub fn setup(app: &mut App) -> Result<(), Box<dyn Error>> {
 
     initialize_windows_and_settings(app_handle, settings.as_ref(), &shell_manger);
 
-    // Start the read-only local API if the user has enabled it (no-op otherwise).
     app_handle
         .state::<crate::local_api::LocalApiManager>()
         .reconcile(settings.as_ref());

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -34,6 +34,11 @@ pub fn setup(app: &mut App) -> Result<(), Box<dyn Error>> {
 
     initialize_windows_and_settings(app_handle, settings.as_ref(), &shell_manger);
 
+    // Start the read-only local API if the user has enabled it (no-op otherwise).
+    app_handle
+        .state::<crate::local_api::LocalApiManager>()
+        .reconcile(settings.as_ref());
+
     app_handle.manage(shell_manger);
 
     info!("starting app v{}", context.version);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -57,6 +57,9 @@ export interface LocalApiStatus {
 
 export const getLocalApiStatus = (): Promise<LocalApiStatus> => invoke("get_local_api_status");
 
+// Apply local API settings on demand (Apply/Restart button); returns new status.
+export const restartLocalApi = (): Promise<LocalApiStatus> => invoke("restart_local_api");
+
 export const getDbInfo = (minDuration: number): Promise<EncounterDbInfo> => invoke("get_db_info", { minDuration });
 
 export const openDbPath = (): Promise<void> => invoke("open_db_path");

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -49,6 +49,14 @@ export const saveSettings = (settings: AppSettings): Promise<void> => invoke("sa
 
 export const getSettings = (): Promise<AppSettings> => invoke("get_settings");
 
+export interface LocalApiStatus {
+  running: boolean;
+  port: number | null;
+  error: string | null;
+}
+
+export const getLocalApiStatus = (): Promise<LocalApiStatus> => invoke("get_local_api_status");
+
 export const getDbInfo = (minDuration: number): Promise<EncounterDbInfo> => invoke("get_db_info", { minDuration });
 
 export const openDbPath = (): Promise<void> => invoke("open_db_path");

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -57,7 +57,6 @@ export interface LocalApiStatus {
 
 export const getLocalApiStatus = (): Promise<LocalApiStatus> => invoke("get_local_api_status");
 
-// Apply local API settings on demand (Apply/Restart button); returns new status.
 export const restartLocalApi = (): Promise<LocalApiStatus> => invoke("restart_local_api");
 
 export const getDbInfo = (minDuration: number): Promise<EncounterDbInfo> => invoke("get_db_info", { minDuration });
@@ -232,4 +231,3 @@ export const onClearEncounter = (handler: (event: { payload: number }) => void) 
 export const onNinevehUpdate = (handler: (event: NinevehEvent) => void) => listen("nineveh-update", handler);
 
 export const onBannedEvent = (handler: () => void) => listen("banned-event", handler);
-

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -127,6 +127,13 @@ export interface BuffSettings {
   default: boolean;
 }
 
+export interface LocalApiSettings {
+  enabled: boolean;
+  port: number;
+  token: string;
+  allowedOrigins: string[];
+}
+
 export interface AppSettings {
   general: GeneralSettings;
   shortcuts: Shortcuts;
@@ -134,4 +141,5 @@ export interface AppSettings {
   logs: LogsSettings;
   mini: MiniSettings;
   buffs: BuffSettings;
+  localApi: LocalApiSettings;
 }

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -337,7 +337,7 @@ export const defaultSettings: AppSettings = {
   },
   localApi: {
     enabled: false,
-    port: 6041,
+    port: 16724,
     token: "",
     allowedOrigins: [
       "https://neria.dev",

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -334,6 +334,17 @@ export const defaultSettings: AppSettings = {
   },
   buffs: {
     default: true
+  },
+  localApi: {
+    enabled: false,
+    port: 6041,
+    token: "",
+    allowedOrigins: [
+      "https://neria.dev",
+      "https://dev-neria.niome.dev",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173"
+    ]
   }
 };
 

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -339,12 +339,7 @@ export const defaultSettings: AppSettings = {
     enabled: false,
     port: 16724,
     token: "",
-    allowedOrigins: [
-      "https://neria.dev",
-      "https://dev-neria.niome.dev",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173"
-    ]
+    allowedOrigins: []
   }
 };
 

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -19,6 +19,7 @@
   import Header from "../Header.svelte";
   import ClassColors from "./ClassColors.svelte";
   import DatabaseInfo from "./DatabaseInfo.svelte";
+  import LocalApi from "./LocalApi.svelte";
   import Shortcuts from "./Shortcuts.svelte";
 
   let currentTab = $state("General");
@@ -238,6 +239,7 @@
       {@render settingsTab("Colors")}
       {@render settingsTab("Shortcuts")}
       {@render settingsTab("Database")}
+      {@render settingsTab("Local API")}
     </div>
     <div class="flex flex-col gap-2 px-4 py-2">
       {#if currentTab === "General"}
@@ -1051,6 +1053,8 @@
         <ClassColors />
       {:else if currentTab === "Shortcuts"}
         <Shortcuts />
+      {:else if currentTab === "Local API"}
+        <LocalApi />
       {/if}
     </div>
   </div>

--- a/src/routes/(app)/settings/LocalApi.svelte
+++ b/src/routes/(app)/settings/LocalApi.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getLocalApiStatus, saveSettings, type LocalApiStatus } from "$lib/api";
+  import { getLocalApiStatus, restartLocalApi, saveSettings, type LocalApiStatus } from "$lib/api";
   import { addToast } from "$lib/components/Toaster.svelte";
   import { settings } from "$lib/stores.svelte";
   import { onMount } from "svelte";
@@ -38,13 +38,35 @@
 
   async function apply() {
     syncOrigins();
+    // Guard against an emptied/invalid port field persisting a null.
+    if (!settings.app.localApi.port || settings.app.localApi.port < 1) {
+      settings.app.localApi.port = 16724;
+    }
     // A token is required for the server to start.
     if (settings.app.localApi.enabled && !settings.app.localApi.token) {
       settings.app.localApi.token = genToken();
     }
     await saveSettings(settings.app);
-    await refreshStatus();
+    // Reconcile only happens here (not on every save), so unrelated saves and
+    // multi-window settings sync never restart the listener.
+    await restartLocalApi();
+    // The server binds asynchronously, so poll until it's actually up (or
+    // errors) rather than flashing a stale "stopped".
+    await pollStatus(settings.app.localApi.enabled);
     addToast({ data: { title: "", description: "Local API settings applied", color: "border-green-500/30" } });
+  }
+
+  async function pollStatus(expectRunning = true) {
+    checking = true;
+    try {
+      for (let i = 0; i < 10; i++) {
+        status = await getLocalApiStatus();
+        if (!expectRunning || status.running || status.error) break;
+        await new Promise((r) => setTimeout(r, 300));
+      }
+    } finally {
+      checking = false;
+    }
   }
 
   async function refreshStatus() {
@@ -82,55 +104,57 @@
     </div>
   </label>
 
-  <label class="flex items-center">
-    <input
-      type="number"
-      class="form-input h-8 w-24 rounded-md border-0 bg-neutral-700 text-sm focus:ring-0"
-      bind:value={settings.app.localApi.port}
-    />
-    <div class="ml-5">
-      <div class="text-sm">Port</div>
-      <div class="text-xs text-neutral-300">Default is 6041.</div>
-    </div>
-  </label>
-
-  <div class="flex flex-col gap-1">
-    <div class="text-sm">API Token</div>
-    <div class="flex items-center gap-2">
+  {#if settings.app.localApi.enabled}
+    <label class="flex items-center">
       <input
-        type={showToken ? "text" : "password"}
-        class="form-input h-8 w-96 rounded-md border-0 bg-neutral-700 font-mono text-xs focus:ring-0"
-        bind:value={settings.app.localApi.token}
-        placeholder="generate a token"
+        type="number"
+        class="form-input h-8 w-24 rounded-md border-0 bg-neutral-700 text-sm focus:ring-0"
+        bind:value={settings.app.localApi.port}
       />
-      <button
-        class="rounded-md bg-neutral-700 px-2 py-1 text-xs hover:bg-neutral-600"
-        onclick={() => (showToken = !showToken)}
-      >
-        {showToken ? "Hide" : "Show"}
-      </button>
-      <button class="rounded-md bg-neutral-700 px-2 py-1 text-xs hover:bg-neutral-600" onclick={copyToken}>
-        Copy
-      </button>
-      <button class="rounded-md bg-neutral-700 px-2 py-1 text-xs hover:bg-neutral-600" onclick={regenerateToken}>
-        Regenerate
-      </button>
-    </div>
-    <div class="text-xs text-neutral-300">
-      Required for all data requests (sent as <span class="font-mono">Authorization: Bearer &lt;token&gt;</span>). Paste
-      this into Neria's local meter settings.
-    </div>
-  </div>
+      <div class="ml-5">
+        <div class="text-sm">Port</div>
+        <div class="text-xs text-neutral-300">Default is 16724.</div>
+      </div>
+    </label>
 
-  <div class="flex flex-col gap-1">
-    <div class="text-sm">Allowed Origins</div>
-    <textarea
-      class="form-textarea h-28 w-96 rounded-md border-0 bg-neutral-700 font-mono text-xs focus:ring-0"
-      bind:value={originsText}
-      onblur={syncOrigins}
-    ></textarea>
-    <div class="text-xs text-neutral-300">One origin per line. Only these websites may read your meter data.</div>
-  </div>
+    <div class="flex flex-col gap-1">
+      <div class="text-sm">API Token</div>
+      <div class="flex items-center gap-2">
+        <input
+          type={showToken ? "text" : "password"}
+          class="form-input h-8 w-96 rounded-md border-0 bg-neutral-700 font-mono text-xs focus:ring-0"
+          bind:value={settings.app.localApi.token}
+          placeholder="generate a token"
+        />
+        <button
+          class="rounded-md bg-neutral-700 px-2 py-1 text-xs hover:bg-neutral-600"
+          onclick={() => (showToken = !showToken)}
+        >
+          {showToken ? "Hide" : "Show"}
+        </button>
+        <button class="rounded-md bg-neutral-700 px-2 py-1 text-xs hover:bg-neutral-600" onclick={copyToken}>
+          Copy
+        </button>
+        <button class="rounded-md bg-neutral-700 px-2 py-1 text-xs hover:bg-neutral-600" onclick={regenerateToken}>
+          Regenerate
+        </button>
+      </div>
+      <div class="text-xs text-neutral-300">
+        Required for all data requests (sent as <span class="font-mono">Authorization: Bearer &lt;token&gt;</span>).
+        Paste this into Neria's local meter settings.
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-1">
+      <div class="text-sm">Allowed Origins</div>
+      <textarea
+        class="form-textarea h-28 w-96 rounded-md border-0 bg-neutral-700 font-mono text-xs focus:ring-0"
+        bind:value={originsText}
+        onblur={syncOrigins}
+      ></textarea>
+      <div class="text-xs text-neutral-300">One origin per line. Only these websites may read your meter data.</div>
+    </div>
+  {/if}
 
   <div class="flex items-center gap-3">
     <button class="bg-accent-800/80 hover:bg-accent-700/80 rounded-md px-3 py-1.5 text-sm" onclick={apply}>

--- a/src/routes/(app)/settings/LocalApi.svelte
+++ b/src/routes/(app)/settings/LocalApi.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import { getLocalApiStatus, saveSettings, type LocalApiStatus } from "$lib/api";
+  import { addToast } from "$lib/components/Toaster.svelte";
+  import { settings } from "$lib/stores.svelte";
+  import { onMount } from "svelte";
+
+  let showToken = $state(false);
+  let status = $state<LocalApiStatus | null>(null);
+  let checking = $state(false);
+  let originsText = $state(settings.app.localApi.allowedOrigins.join("\n"));
+
+  function genToken(): string {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  }
+
+  function regenerateToken() {
+    settings.app.localApi.token = genToken();
+    showToken = true;
+  }
+
+  async function copyToken() {
+    try {
+      await navigator.clipboard.writeText(settings.app.localApi.token);
+      addToast({ data: { title: "", description: "Token copied", color: "border-green-500/30" } });
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  function syncOrigins() {
+    settings.app.localApi.allowedOrigins = originsText
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+
+  async function apply() {
+    syncOrigins();
+    // A token is required for the server to start.
+    if (settings.app.localApi.enabled && !settings.app.localApi.token) {
+      settings.app.localApi.token = genToken();
+    }
+    await saveSettings(settings.app);
+    await refreshStatus();
+    addToast({ data: { title: "", description: "Local API settings applied", color: "border-green-500/30" } });
+  }
+
+  async function refreshStatus() {
+    checking = true;
+    try {
+      status = await getLocalApiStatus();
+    } catch (e) {
+      console.error(e);
+      status = null;
+    } finally {
+      checking = false;
+    }
+  }
+
+  onMount(refreshStatus);
+</script>
+
+<div class="flex max-w-2xl flex-col gap-4">
+  <div class="text-sm text-neutral-300">
+    Exposes a <span class="font-semibold">read-only</span> API on
+    <span class="font-mono">127.0.0.1</span> so an allow-listed website (e.g. neria.dev) can detect your private
+    clears. Only sanitized clear summaries are shared — never combat logs, damage, or party details. Disabled by
+    default.
+  </div>
+
+  <label class="flex items-center gap-2">
+    <input
+      type="checkbox"
+      bind:checked={settings.app.localApi.enabled}
+      class="form-checkbox size-5 rounded-sm border-0 bg-neutral-700 checked:text-accent-600/80 focus:ring-0"
+    />
+    <div class="ml-3">
+      <div class="text-sm">Enable Local API</div>
+      <div class="text-xs text-neutral-300">Starts a localhost-only HTTP server when applied.</div>
+    </div>
+  </label>
+
+  <label class="flex items-center">
+    <input
+      type="number"
+      class="form-input h-8 w-24 rounded-md border-0 bg-neutral-700 text-sm focus:ring-0"
+      bind:value={settings.app.localApi.port}
+    />
+    <div class="ml-5">
+      <div class="text-sm">Port</div>
+      <div class="text-xs text-neutral-300">Default is 6041.</div>
+    </div>
+  </label>
+
+  <div class="flex flex-col gap-1">
+    <div class="text-sm">API Token</div>
+    <div class="flex items-center gap-2">
+      <input
+        type={showToken ? "text" : "password"}
+        class="form-input h-8 w-96 rounded-md border-0 bg-neutral-700 font-mono text-xs focus:ring-0"
+        bind:value={settings.app.localApi.token}
+        placeholder="generate a token"
+      />
+      <button
+        class="rounded-md bg-neutral-700 px-2 py-1 text-xs hover:bg-neutral-600"
+        onclick={() => (showToken = !showToken)}
+      >
+        {showToken ? "Hide" : "Show"}
+      </button>
+      <button class="rounded-md bg-neutral-700 px-2 py-1 text-xs hover:bg-neutral-600" onclick={copyToken}>
+        Copy
+      </button>
+      <button class="rounded-md bg-neutral-700 px-2 py-1 text-xs hover:bg-neutral-600" onclick={regenerateToken}>
+        Regenerate
+      </button>
+    </div>
+    <div class="text-xs text-neutral-300">
+      Required for all data requests (sent as <span class="font-mono">Authorization: Bearer &lt;token&gt;</span>). Paste
+      this into Neria's local meter settings.
+    </div>
+  </div>
+
+  <div class="flex flex-col gap-1">
+    <div class="text-sm">Allowed Origins</div>
+    <textarea
+      class="form-textarea h-28 w-96 rounded-md border-0 bg-neutral-700 font-mono text-xs focus:ring-0"
+      bind:value={originsText}
+      onblur={syncOrigins}
+    ></textarea>
+    <div class="text-xs text-neutral-300">One origin per line. Only these websites may read your meter data.</div>
+  </div>
+
+  <div class="flex items-center gap-3">
+    <button class="bg-accent-800/80 hover:bg-accent-700/80 rounded-md px-3 py-1.5 text-sm" onclick={apply}>
+      Apply / Restart
+    </button>
+    <button class="rounded-md bg-neutral-700 px-3 py-1.5 text-sm hover:bg-neutral-600" onclick={refreshStatus}>
+      Refresh Status
+    </button>
+    <div class="text-xs">
+      {#if checking}
+        <span class="text-neutral-400">checking…</span>
+      {:else if status?.running}
+        <span class="text-green-400">running on 127.0.0.1:{status.port}</span>
+      {:else if status?.error}
+        <span class="text-red-400">error: {status.error}</span>
+      {:else}
+        <span class="text-neutral-400">stopped</span>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/src/routes/(app)/settings/LocalApi.svelte
+++ b/src/routes/(app)/settings/LocalApi.svelte
@@ -38,20 +38,14 @@
 
   async function apply() {
     syncOrigins();
-    // Guard against an emptied/invalid port field persisting a null.
     if (!settings.app.localApi.port || settings.app.localApi.port < 1) {
       settings.app.localApi.port = 16724;
     }
-    // A token is required for the server to start.
     if (settings.app.localApi.enabled && !settings.app.localApi.token) {
       settings.app.localApi.token = genToken();
     }
     await saveSettings(settings.app);
-    // Reconcile only happens here (not on every save), so unrelated saves and
-    // multi-window settings sync never restart the listener.
     await restartLocalApi();
-    // The server binds asynchronously, so poll until it's actually up (or
-    // errors) rather than flashing a stale "stopped".
     await pollStatus(settings.app.localApi.enabled);
     addToast({ data: { title: "", description: "Local API settings applied", color: "border-green-500/30" } });
   }
@@ -87,9 +81,7 @@
 <div class="flex max-w-2xl flex-col gap-4">
   <div class="text-sm text-neutral-300">
     Exposes a <span class="font-semibold">read-only</span> API on
-    <span class="font-mono">127.0.0.1</span> so an allow-listed website (e.g. neria.dev) can detect your private
-    clears. Only sanitized clear summaries are shared — never combat logs, damage, or party details. Disabled by
-    default.
+    <span class="font-mono">127.0.0.1</span> so allow-listed websites can read sanitized clear summaries. Disabled by default.
   </div>
 
   <label class="flex items-center gap-2">
@@ -141,23 +133,23 @@
       </div>
       <div class="text-xs text-neutral-300">
         Required for all data requests (sent as <span class="font-mono">Authorization: Bearer &lt;token&gt;</span>).
-        Paste this into Neria's local meter settings.
       </div>
     </div>
 
     <div class="flex flex-col gap-1">
       <div class="text-sm">Allowed Origins</div>
       <textarea
-        class="form-textarea h-28 w-96 rounded-md border-0 bg-neutral-700 font-mono text-xs focus:ring-0"
+        class="h-28 w-96 form-textarea rounded-md border-0 bg-neutral-700 font-mono text-xs focus:ring-0"
         bind:value={originsText}
         onblur={syncOrigins}
+        placeholder="https://example.com"
       ></textarea>
       <div class="text-xs text-neutral-300">One origin per line. Only these websites may read your meter data.</div>
     </div>
   {/if}
 
   <div class="flex items-center gap-3">
-    <button class="bg-accent-800/80 hover:bg-accent-700/80 rounded-md px-3 py-1.5 text-sm" onclick={apply}>
+    <button class="rounded-md bg-accent-800/80 px-3 py-1.5 text-sm hover:bg-accent-700/80" onclick={apply}>
       Apply / Restart
     </button>
     <button class="rounded-md bg-neutral-700 px-3 py-1.5 text-sm hover:bg-neutral-600" onclick={refreshStatus}>

--- a/src/routes/(app)/settings/LocalApi.svelte
+++ b/src/routes/(app)/settings/LocalApi.svelte
@@ -7,6 +7,7 @@
   let showToken = $state(false);
   let status = $state<LocalApiStatus | null>(null);
   let checking = $state(false);
+  let applying = $state(false);
   let originsText = $state(settings.app.localApi.allowedOrigins.join("\n"));
 
   function genToken(): string {
@@ -36,21 +37,63 @@
       .filter((s) => s.length > 0);
   }
 
-  async function apply() {
+  function normalizeSettings() {
     syncOrigins();
     if (!settings.app.localApi.port || settings.app.localApi.port < 1) {
       settings.app.localApi.port = 16724;
     }
     if (settings.app.localApi.enabled && !settings.app.localApi.token) {
       settings.app.localApi.token = genToken();
+      showToken = true;
     }
-    await saveSettings(settings.app);
-    await restartLocalApi();
-    await pollStatus(settings.app.localApi.enabled);
-    addToast({ data: { title: "", description: "Local API settings applied", color: "border-green-500/30" } });
   }
 
-  async function pollStatus(expectRunning = true) {
+  async function apply(expectRunning = settings.app.localApi.enabled) {
+    applying = true;
+    try {
+      normalizeSettings();
+      await saveSettings(settings.app);
+      await restartLocalApi();
+      const next = await pollStatus(expectRunning);
+
+      if (!settings.app.localApi.enabled) {
+        addToast({ data: { title: "", description: "Local API stopped", color: "border-neutral-500/30" } });
+      } else if (next?.running) {
+        addToast({
+          data: {
+            title: "",
+            description: `Local API running on 127.0.0.1:${next.port}`,
+            color: "border-green-500/30"
+          }
+        });
+      } else {
+        addToast({
+          data: {
+            title: "",
+            description: next?.error ? `Local API error: ${next.error}` : "Local API did not start",
+            color: "border-red-500/30"
+          }
+        });
+      }
+    } catch (e) {
+      addToast({
+        data: {
+          title: "",
+          description: e instanceof Error ? e.message : "Local API settings failed",
+          color: "border-red-500/30"
+        }
+      });
+    } finally {
+      applying = false;
+    }
+  }
+
+  async function setEnabled(enabled: boolean) {
+    settings.app.localApi.enabled = enabled;
+    await apply(enabled);
+  }
+
+  async function pollStatus(expectRunning = true): Promise<LocalApiStatus | null> {
     checking = true;
     try {
       for (let i = 0; i < 10; i++) {
@@ -58,24 +101,15 @@
         if (!expectRunning || status.running || status.error) break;
         await new Promise((r) => setTimeout(r, 300));
       }
+      return status;
     } finally {
       checking = false;
     }
   }
 
-  async function refreshStatus() {
-    checking = true;
-    try {
-      status = await getLocalApiStatus();
-    } catch (e) {
-      console.error(e);
-      status = null;
-    } finally {
-      checking = false;
-    }
-  }
-
-  onMount(refreshStatus);
+  onMount(() => {
+    void pollStatus(settings.app.localApi.enabled);
+  });
 </script>
 
 <div class="flex max-w-2xl flex-col gap-4">
@@ -87,12 +121,13 @@
   <label class="flex items-center gap-2">
     <input
       type="checkbox"
-      bind:checked={settings.app.localApi.enabled}
+      checked={settings.app.localApi.enabled}
+      onchange={(e) => setEnabled((e.currentTarget as HTMLInputElement).checked)}
       class="form-checkbox size-5 rounded-sm border-0 bg-neutral-700 checked:text-accent-600/80 focus:ring-0"
     />
     <div class="ml-3">
       <div class="text-sm">Enable Local API</div>
-      <div class="text-xs text-neutral-300">Starts a localhost-only HTTP server when applied.</div>
+      <div class="text-xs text-neutral-300">Starts or stops the localhost-only HTTP server.</div>
     </div>
   </label>
 
@@ -149,12 +184,15 @@
   {/if}
 
   <div class="flex items-center gap-3">
-    <button class="rounded-md bg-accent-800/80 px-3 py-1.5 text-sm hover:bg-accent-700/80" onclick={apply}>
-      Apply / Restart
-    </button>
-    <button class="rounded-md bg-neutral-700 px-3 py-1.5 text-sm hover:bg-neutral-600" onclick={refreshStatus}>
-      Refresh Status
-    </button>
+    {#if settings.app.localApi.enabled}
+      <button
+        class="rounded-md bg-accent-800/80 px-3 py-1.5 text-sm hover:bg-accent-700/80 disabled:opacity-50"
+        disabled={applying || checking}
+        onclick={() => apply(true)}
+      >
+        {applying ? "Applying…" : "Apply / Restart"}
+      </button>
+    {/if}
     <div class="text-xs">
       {#if checking}
         <span class="text-neutral-400">checking…</span>


### PR DESCRIPTION
This adds an opt-in Local API that lets browser-based tools read a small, sanitized view of the local meter over `127.0.0.1`. The goal is to support local clear detection without exposing full combat logs. The API is disabled by default, only binds to localhost, requires a bearer token, and only responds to origins the user explicitly allow-lists.

The API is versioned under `/v1` and currently includes:

- `GET /v1/status`
Returns API health, app/version info, schema version, and server time.

- `GET /v1/encounters?sinceMs=&untilMs=`
Returns cleared encounters in the requested time window, using the NTP-backed fight start timestamp.

- `GET /v1/characters?names=`
Returns basic local character metadata for matching names.

The encounter response is intentionally limited to clear detection fields: encounter id, boss, difficulty, fight start, duration, local player, clear state, and uploaded log id when available. It does not expose damage logs, skill or buff data, party details, player breakdowns, or full encounter payloads.


There is a new **Local API** settings tab where users can enable the API, choose a port, manage the token, and configure allowed origins. Disabling the setting stops the server immediately. When enabled, users can still press **Apply / Restart** after changing port, token, or origins. The page shows the current server status and uses the existing toast system for start/stop/error feedback.


The server is managed through a `LocalApiManager` Tauri state object and runs an Axum router on `127.0.0.1`. CORS is exact-match only, credentials are not used, responses are marked `Cache-Control: no-store`, and Chromium Private Network Access preflights are handled for allowed origins.

Encounter export requires the NTP-backed fight start timestamp and skips rows that do not have one.