### PR TITLE
Add Linux installer and self-updating launcher

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -5,7 +5,35 @@ LOA Logs on Linux is split into two programs:
 - Nineveh: backend game packet reader
 - LOA Logs: main frontend application, delivered as an AppImage
 
-## How to run it
+## Option 1: Automated installer (recommended)
+
+The included install script downloads the latest release, sets up a desktop entry, and creates a launcher that
+auto-updates both the AppImage and nineveh on each start.
+
+Requirements: `curl`, `python3`, `pkexec`, `pgrep` (standard on most desktop Linux distributions).
+
+```bash
+git clone https://github.com/snoww/loa-logs.git
+cd loa-logs/scripts/linux
+./install.sh
+```
+
+This will:
+
+- Download the latest AppImage and nineveh binary to `~/.local/share/loa-logs/`
+- Install a desktop entry so LOA Logs appears in your application menu
+- Set up a launcher that automatically checks for updates on each start
+
+To uninstall:
+
+```bash
+cd loa-logs/scripts/linux
+./uninstall.sh
+```
+
+Your encounter data and settings are preserved on uninstall.
+
+## Option 2: Manual setup
 
 Download the newest AppImage and `nineveh` from the [latest release](https://github.com/snoww/loa-logs/releases).
 
@@ -24,14 +52,14 @@ sudo ./nineveh --stop-after-timeout 0 --proxy-without-ipc
 
 Then open the LOA Logs AppImage.
 
-## Updates
+### Manual updates
 
 The main LOA Logs AppImage should update like it does on Windows.
 
 Nineveh needs to be updated manually after game updates or patches. If LOA Logs stops working after a patch, check the
 releases page for a newer Nineveh download.
 
-## Example script
+### Example script
 
 This script assumes you renamed the AppImage to `LOA_Logs.appimage`. Change `location` to your LOA Logs folder before
 running it.

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="snoww/loa-logs"
+INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/loa-logs"
+DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+ICON_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+info() { echo "[loa-logs] $*"; }
+error() { echo "[loa-logs] ERROR: $*" >&2; }
+
+check_deps() {
+    local missing=()
+    for cmd in curl python3 pkexec pgrep; do
+        if ! command -v "$cmd" > /dev/null 2>&1; then
+            missing+=("$cmd")
+        fi
+    done
+    if [ ${#missing[@]} -gt 0 ]; then
+        error "Missing required commands: ${missing[*]}"
+        error "Install them with your package manager before running this script."
+        exit 1
+    fi
+}
+
+get_latest_release() {
+    curl -sf --max-time 10 "https://api.github.com/repos/$REPO/releases/latest"
+}
+
+parse_tag() {
+    python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])"
+}
+
+parse_asset_url() {
+    local pattern="$1"
+    python3 -c "
+import sys, json
+assets = json.load(sys.stdin)['assets']
+for a in assets:
+    if $pattern:
+        print(a['browser_download_url'])
+        break
+"
+}
+
+main() {
+    check_deps
+
+    info "Fetching latest release info..."
+    local release_json
+    release_json=$(get_latest_release) || {
+        error "Could not reach GitHub API."
+        exit 1
+    }
+
+    local version
+    version=$(echo "$release_json" | parse_tag) || {
+        error "Could not parse release info."
+        exit 1
+    }
+    info "Latest version: $version"
+
+    local appimage_url nineveh_url
+    appimage_url=$(echo "$release_json" | parse_asset_url \
+        "a['name'].lower().endswith('.appimage')") || {
+        error "No AppImage found in release."
+        exit 1
+    }
+    nineveh_url=$(echo "$release_json" | parse_asset_url \
+        "a['name'] == 'nineveh'") || {
+        error "No nineveh binary found in release."
+        exit 1
+    }
+
+    mkdir -p "$INSTALL_DIR" "$DESKTOP_DIR" "$ICON_DIR"
+
+    info "Downloading AppImage..."
+    curl -fL --progress-bar -o "$INSTALL_DIR/loa-logs.appimage" "$appimage_url"
+    chmod +x "$INSTALL_DIR/loa-logs.appimage"
+
+    info "Downloading nineveh..."
+    curl -fL --progress-bar -o "$INSTALL_DIR/nineveh" "$nineveh_url"
+    chmod +x "$INSTALL_DIR/nineveh"
+
+    echo "$version" > "$INSTALL_DIR/.version"
+
+    info "Installing launcher scripts..."
+    cp "$SCRIPT_DIR/start-loa.sh" "$INSTALL_DIR/start-loa.sh"
+    cp "$SCRIPT_DIR/nineveh-helper.sh" "$INSTALL_DIR/nineveh-helper.sh"
+    chmod +x "$INSTALL_DIR/start-loa.sh" "$INSTALL_DIR/nineveh-helper.sh"
+
+    info "Installing desktop entry..."
+    local icon_src="$SCRIPT_DIR/../../src-tauri/icons/icon.png"
+    if [ -f "$icon_src" ]; then
+        cp "$icon_src" "$ICON_DIR/loa-logs.png"
+    else
+        info "Icon not found in repo, downloading from GitHub..."
+        curl -sfL -o "$ICON_DIR/loa-logs.png" \
+            "https://raw.githubusercontent.com/$REPO/master/src-tauri/icons/icon.png" || {
+            error "Could not download icon."
+        }
+    fi
+
+    cat > "$DESKTOP_DIR/loa-logs.desktop" <<DESKTOP
+[Desktop Entry]
+Name=LOA Logs
+Comment=Lost Ark DPS meter with auto-updating launcher
+Exec=$INSTALL_DIR/start-loa.sh
+Terminal=false
+Type=Application
+Icon=$ICON_DIR/loa-logs.png
+Categories=Utility;Game;
+DESKTOP
+
+    info "Installation complete!"
+    info "  Install directory: $INSTALL_DIR"
+    info "  Version: $version"
+    info "  Launch from your application menu or run: $INSTALL_DIR/start-loa.sh"
+}
+
+main "$@"

--- a/scripts/linux/nineveh-helper.sh
+++ b/scripts/linux/nineveh-helper.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Runs as root via pkexec.
+# Kills any existing nineveh, starts a new one, watches for stop signal.
+
+NINEVEH_BIN="$1"
+STOP_FILE="$2"
+shift 2
+NINEVEH_ARGS="$@"
+NINEVEH_PID=""
+
+cleanup() {
+    if [ -n "$NINEVEH_PID" ] && kill -0 "$NINEVEH_PID" 2>/dev/null; then
+        kill "$NINEVEH_PID" 2>/dev/null
+        wait "$NINEVEH_PID" 2>/dev/null
+    fi
+    rm -f "$STOP_FILE"
+    exit 0
+}
+
+trap cleanup SIGINT SIGTERM SIGHUP
+
+EXISTING=$(pgrep -x "$(basename "$NINEVEH_BIN")")
+if [ -n "$EXISTING" ]; then
+    kill $EXISTING 2>/dev/null
+    sleep 1
+fi
+
+$NINEVEH_BIN $NINEVEH_ARGS &
+NINEVEH_PID=$!
+
+while kill -0 "$NINEVEH_PID" 2>/dev/null; do
+    if [ -f "$STOP_FILE" ]; then
+        cleanup
+    fi
+    sleep 1
+done

--- a/scripts/linux/start-loa.sh
+++ b/scripts/linux/start-loa.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+set -euo pipefail
+
+INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_FILE="$INSTALL_DIR/start-loa.log"
+VERSION_FILE="$INSTALL_DIR/.version"
+STOP_FILE="$INSTALL_DIR/.nineveh-stop"
+APPIMAGE="$INSTALL_DIR/loa-logs.appimage"
+NINEVEH_BIN="$INSTALL_DIR/nineveh"
+HELPER="$INSTALL_DIR/nineveh-helper.sh"
+
+REPO="snoww/loa-logs"
+
+LOA_PID=""
+HELPER_PID=""
+EXIT_CODE=0
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+echo "===== LOA Logs launcher started at $(date) =====" > "$LOG_FILE"
+
+cleanup() {
+    log "Shutting down..."
+    if [ -n "$LOA_PID" ] && kill -0 "$LOA_PID" 2>/dev/null; then
+        kill "$LOA_PID" 2>/dev/null
+        wait "$LOA_PID" 2>/dev/null
+        log "LOA Logs stopped."
+    fi
+    if pgrep -x nineveh > /dev/null 2>&1; then
+        log "Signaling nineveh to stop..."
+        touch "$STOP_FILE"
+        for _ in $(seq 1 5); do
+            pgrep -x nineveh > /dev/null 2>&1 || break
+            sleep 1
+        done
+        if pgrep -x nineveh > /dev/null 2>&1; then
+            log "WARNING: nineveh did not stop in time."
+        else
+            log "nineveh stopped."
+        fi
+    fi
+    rm -f "$STOP_FILE"
+    log "Cleanup complete."
+    exit "$EXIT_CODE"
+}
+
+trap cleanup SIGINT SIGTERM SIGHUP EXIT
+rm -f "$STOP_FILE"
+
+check_for_updates() {
+    local current_version=""
+    if [ -f "$VERSION_FILE" ]; then
+        current_version=$(cat "$VERSION_FILE")
+    fi
+
+    log "Checking for updates (current: ${current_version:-none})..."
+
+    local release_json
+    release_json=$(curl -sf --max-time 10 \
+        "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null) || {
+        log "WARNING: Could not reach GitHub API, skipping update check."
+        return 1
+    }
+
+    local latest_tag
+    latest_tag=$(echo "$release_json" | python3 -c \
+        "import sys,json; print(json.load(sys.stdin)['tag_name'])" 2>/dev/null) || {
+        log "WARNING: Could not parse release info."
+        return 1
+    }
+
+    if [ "$latest_tag" = "$current_version" ]; then
+        log "Already on latest version ($current_version)."
+        return 1
+    fi
+
+    log "New version available: $latest_tag (current: ${current_version:-none})"
+
+    local appimage_url nineveh_url
+    appimage_url=$(echo "$release_json" | python3 -c "
+import sys, json
+assets = json.load(sys.stdin)['assets']
+for a in assets:
+    if a['name'].lower().endswith('.appimage'):
+        print(a['browser_download_url'])
+        break
+" 2>/dev/null) || {
+        log "ERROR: Could not find AppImage in release assets."
+        return 1
+    }
+
+    nineveh_url=$(echo "$release_json" | python3 -c "
+import sys, json
+assets = json.load(sys.stdin)['assets']
+for a in assets:
+    if a['name'] == 'nineveh':
+        print(a['browser_download_url'])
+        break
+" 2>/dev/null) || {
+        log "ERROR: Could not find nineveh in release assets."
+        return 1
+    }
+
+    if [ -z "$appimage_url" ] || [ -z "$nineveh_url" ]; then
+        log "ERROR: Missing download URLs in release."
+        return 1
+    fi
+
+    log "Downloading AppImage..."
+    if ! curl -fL --progress-bar -o "$APPIMAGE.tmp" "$appimage_url" 2>>"$LOG_FILE"; then
+        log "ERROR: AppImage download failed."
+        rm -f "$APPIMAGE.tmp"
+        return 1
+    fi
+
+    log "Downloading nineveh..."
+    if ! curl -fL --progress-bar -o "$NINEVEH_BIN.tmp" "$nineveh_url" 2>>"$LOG_FILE"; then
+        log "ERROR: nineveh download failed."
+        rm -f "$APPIMAGE.tmp" "$NINEVEH_BIN.tmp"
+        return 1
+    fi
+
+    mv "$APPIMAGE.tmp" "$APPIMAGE"
+    chmod +x "$APPIMAGE"
+    mv "$NINEVEH_BIN.tmp" "$NINEVEH_BIN"
+    chmod +x "$NINEVEH_BIN"
+
+    echo "$latest_tag" > "$VERSION_FILE"
+    log "Updated to $latest_tag."
+    return 0
+}
+
+if [ ! -f "$APPIMAGE" ] || [ ! -f "$NINEVEH_BIN" ]; then
+    log "Missing binaries, downloading latest release..."
+    rm -f "$VERSION_FILE"
+    if ! check_for_updates; then
+        log "ERROR: Could not download binaries. Cannot start."
+        EXIT_CODE=1; exit 1
+    fi
+else
+    check_for_updates || true
+fi
+
+log "Starting nineveh (requires authentication)..."
+pkexec "$HELPER" "$NINEVEH_BIN" "$STOP_FILE" --stop-after-timeout 0 --proxy-without-ipc >> "$LOG_FILE" 2>&1 &
+HELPER_PID=$!
+log "nineveh helper launched (PID $HELPER_PID)"
+
+log "Waiting for nineveh to initialize..."
+TIMEOUT=30
+ELAPSED=0
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+    if [ "$ELAPSED" -gt 3 ] && ! pgrep -x nineveh > /dev/null 2>&1; then
+        log "ERROR: nineveh process died. Check log for details."
+        EXIT_CODE=1; exit 1
+    fi
+    if grep -q "Spawned new proxy server" "$LOG_FILE" 2>/dev/null; then
+        log "nineveh is ready (proxy server spawned)."
+        break
+    fi
+    sleep 1
+    ELAPSED=$((ELAPSED + 1))
+done
+
+if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+    log "WARNING: timed out waiting for nineveh, launching LOA Logs anyway..."
+fi
+
+log "Starting LOA Logs..."
+"$APPIMAGE" >> "$LOG_FILE" 2>&1 &
+LOA_PID=$!
+log "LOA Logs launched with PID $LOA_PID"
+
+wait "$LOA_PID" 2>/dev/null
+LOA_EXIT=$?
+log "LOA Logs exited with code $LOA_EXIT"
+cleanup

--- a/scripts/linux/uninstall.sh
+++ b/scripts/linux/uninstall.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/loa-logs"
+DESKTOP_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/applications/loa-logs.desktop"
+ICON_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/icons/loa-logs.png"
+APP_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/xyz.snow.loa-logs"
+APP_DATA="${XDG_DATA_HOME:-$HOME/.local/share}/xyz.snow.loa-logs"
+
+info() { echo "[loa-logs] $*"; }
+
+if pgrep -x nineveh > /dev/null 2>&1 || pgrep -f "loa-logs.appimage" > /dev/null 2>&1; then
+    info "LOA Logs appears to be running. Please close it first."
+    exit 1
+fi
+
+info "This will remove:"
+info "  $INSTALL_DIR (launcher, binaries, scripts)"
+info "  $DESKTOP_FILE"
+info "  $ICON_FILE"
+echo ""
+
+if [ -d "$APP_DATA" ]; then
+    info "Your encounter data and settings will NOT be removed:"
+    info "  $APP_CONFIG"
+    info "  $APP_DATA"
+    info "To remove those too, delete them manually."
+    echo ""
+fi
+
+read -rp "Proceed with uninstall? [y/N] " confirm
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    info "Cancelled."
+    exit 0
+fi
+
+rm -rf "$INSTALL_DIR"
+rm -f "$DESKTOP_FILE"
+rm -f "$ICON_FILE"
+
+info "Uninstall complete."


### PR DESCRIPTION
## Summary

- Add `scripts/linux/install.sh` for one-time setup (downloads latest release, creates desktop entry)
- Add `scripts/linux/start-loa.sh` launcher that auto-updates both the AppImage and nineveh from GitHub releases on each launch
- Add `scripts/linux/nineveh-helper.sh` for managing nineveh as root via pkexec
- Add `scripts/linux/uninstall.sh` for clean removal (preserves user data)
- Update `docs/linux.md` with the automated installer as the recommended path, keeping the manual setup as an alternative

Resolves #210

## How it works

The launcher checks the GitHub releases API on startup, compares the latest tag against a stored `.version` file, and downloads new binaries if a newer version exists. Downloads use an atomic tmp-then-mv pattern so a failed download never corrupts the current install. If GitHub is unreachable, the existing binaries are used.

Dependencies: `curl`, `python3`, `pkexec`, `pgrep` (standard on desktop Linux).