### PR TITLE
fix: linux launcher cleanup race, silent update fallback, and log retention

### DIFF
--- a/scripts/linux/nineveh-helper.sh
+++ b/scripts/linux/nineveh-helper.sh
@@ -5,7 +5,7 @@
 NINEVEH_BIN="$1"
 STOP_FILE="$2"
 shift 2
-NINEVEH_ARGS="$@"
+NINEVEH_ARGS=("$@")
 NINEVEH_PID=""
 
 cleanup() {
@@ -25,7 +25,7 @@ if [ -n "$EXISTING" ]; then
     sleep 1
 fi
 
-$NINEVEH_BIN $NINEVEH_ARGS &
+"$NINEVEH_BIN" "${NINEVEH_ARGS[@]}" &
 NINEVEH_PID=$!
 
 while kill -0 "$NINEVEH_PID" 2>/dev/null; do

--- a/scripts/linux/start-loa.sh
+++ b/scripts/linux/start-loa.sh
@@ -14,14 +14,23 @@ REPO="snoww/loa-logs"
 LOA_PID=""
 HELPER_PID=""
 EXIT_CODE=0
+CLEANED_UP=0
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
 }
 
-echo "===== LOA Logs launcher started at $(date) =====" > "$LOG_FILE"
+MAX_LOG_LINES=1000
+if [ -f "$LOG_FILE" ]; then
+    tail -n "$MAX_LOG_LINES" "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+fi
+echo "===== LOA Logs launcher started at $(date) =====" >> "$LOG_FILE"
 
 cleanup() {
+    if [ "$CLEANED_UP" -eq 1 ]; then
+        return
+    fi
+    CLEANED_UP=1
     log "Shutting down..."
     if [ -n "$LOA_PID" ] && kill -0 "$LOA_PID" 2>/dev/null; then
         kill "$LOA_PID" 2>/dev/null
@@ -140,7 +149,9 @@ if [ ! -f "$APPIMAGE" ] || [ ! -f "$NINEVEH_BIN" ]; then
         EXIT_CODE=1; exit 1
     fi
 else
-    check_for_updates || true
+    if ! check_for_updates; then
+        log "WARNING: Update check failed, continuing with existing binaries."
+    fi
 fi
 
 log "Starting nineveh (requires authentication)..."


### PR DESCRIPTION
## Summary

- **Fix double cleanup on exit**: Added guard flag to prevent `cleanup()` running twice (explicit call + EXIT trap), which caused race conditions during shutdown
- **Log visible warning on update failure**: Replaced silent `|| true` with explicit WARNING log when update check fails and old binaries are used
- **Log rotation**: Switched from overwrite to append mode with 1000-line cap so previous session logs are preserved
- **Fix argument quoting in nineveh-helper.sh**: Use proper bash array for `NINEVEH_ARGS` to prevent word-splitting issues